### PR TITLE
Merge Feature/deploy to runai to dev branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,10 +168,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Connect to VPN
+        uses: kota65535/github-openvpn-connect-action@v3
+        with:
+          config_file: ${{ secrets.VPN_CONFIG }}
+          username: ${{ secrets.VPN_USERNAME }}
+          password: ${{ secrets.VPN_PASSWORD }}
+
       - name: Install Run:ai CLI
         run: |
-          curl -L https://github.com/run-ai/runai-cli/releases/latest/download/runai-cli-linux-amd64.tar.gz \
-            | tar xz
+          # Download CLI directly from the Run:ai platform (official method)
+          curl -fsSL "${{ env.RUNAI_CLUSTER_URL }}/api/v1/cli/linux" -o runai
+          chmod +x runai
           sudo mv runai /usr/local/bin/runai
           runai version
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,6 +80,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - uses: docker/metadata-action@v5
         id: meta
         with:
@@ -113,6 +116,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - uses: docker/metadata-action@v5
         id: meta

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -230,6 +230,45 @@ jobs:
           echo "    medw-ollama${{ env.SUFFIX }}  ← B200 GPU"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
+      # ── Provision PVCs (idempotent — 409 = already exists) ──────────────
+      - name: Create PVCs
+        run: |
+          create_pvc() {
+            local pvc_name="$1"
+            local size="$2"
+            local PAYLOAD
+            PAYLOAD=$(jq -n \
+              --arg     name      "$pvc_name" \
+              --argjson projectId "$PROJECT_ID" \
+              --arg     clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
+              --arg     size      "$size" \
+              '{
+                name: $name,
+                projectId: $projectId,
+                clusterId: $clusterId,
+                spec: { size: $size }
+              }')
+            echo "Creating PVC: $pvc_name ($size)"
+            RESP=$(curl -sSL -w "\n%{http_code}" -X POST \
+              "${{ env.RUNAI_CLUSTER_URL }}/api/v1/data-sources/pvcs" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer $TOKEN" \
+              -d "$PAYLOAD") || true
+            STATUS=$(echo "$RESP" | tail -1)
+            BODY=$(echo "$RESP" | head -n -1)
+            if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
+              echo "  ✓ $pvc_name created"
+            elif [ "$STATUS" = "409" ]; then
+              echo "  ✓ $pvc_name already exists — skipping"
+            else
+              echo "  ✗ $pvc_name failed (HTTP $STATUS): $BODY"
+              exit 1
+            fi
+          }
+
+          create_pvc "chroma-pvc${SUFFIX}" "10G"
+          create_pvc "ollama-pvc${SUFFIX}"  "50G"
+
       # ── Submit workloads via REST API ────────────────────────────────────
       - name: Deploy ChromaDB
         run: |
@@ -255,22 +294,25 @@ jobs:
                   pvc: [{
                     path: "/chroma/chroma",
                     claimName: $pvc,
-                    size: "10G"
+                    existingPvc: true
                   }]
                 }
               }
             }')
-          RESP=$(curl -fsSL -w "\n%{http_code}" -X POST \
+          RESP=$(curl -sSL -w "\n%{http_code}" -X POST \
             "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $TOKEN" \
             -d "$CHROMA_JSON") || true
           STATUS=$(echo "$RESP" | tail -1)
           BODY=$(echo "$RESP" | head -n -1)
+          echo "ChromaDB response (HTTP $STATUS): $BODY"
           if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
             echo "ChromaDB submitted"
+          elif [ "$STATUS" = "409" ]; then
+            echo "ChromaDB already exists — skipping"
           else
-            echo "ChromaDB failed (HTTP $STATUS): $BODY"
+            echo "ChromaDB failed (HTTP $STATUS): $BODY" && exit 1
           fi
 
       - name: Deploy Backend
@@ -298,11 +340,21 @@ jobs:
                 ports: [{container: 8000, serviceType: "ClusterIP"}]
               }
             }')
-          curl -fsSL -X POST \
+          RESP=$(curl -sSL -w "\n%{http_code}" -X POST \
             "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $TOKEN" \
-            -d "$BACKEND_JSON" && echo "Backend submitted" || echo "Backend submit failed (may already exist)"
+            -d "$BACKEND_JSON") || true
+          STATUS=$(echo "$RESP" | tail -1)
+          BODY=$(echo "$RESP" | head -n -1)
+          echo "Backend response (HTTP $STATUS): $BODY"
+          if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
+            echo "Backend submitted"
+          elif [ "$STATUS" = "409" ]; then
+            echo "Backend already exists — skipping"
+          else
+            echo "Backend failed (HTTP $STATUS): $BODY" && exit 1
+          fi
 
       - name: Deploy Frontend
         run: |
@@ -321,11 +373,21 @@ jobs:
                 ports: [{container: 3000, serviceType: "NodePort"}]
               }
             }')
-          curl -fsSL -X POST \
+          RESP=$(curl -sSL -w "\n%{http_code}" -X POST \
             "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $TOKEN" \
-            -d "$FRONTEND_JSON" && echo "Frontend submitted" || echo "Frontend submit failed (may already exist)"
+            -d "$FRONTEND_JSON") || true
+          STATUS=$(echo "$RESP" | tail -1)
+          BODY=$(echo "$RESP" | head -n -1)
+          echo "Frontend response (HTTP $STATUS): $BODY"
+          if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
+            echo "Frontend submitted"
+          elif [ "$STATUS" = "409" ]; then
+            echo "Frontend already exists — skipping"
+          else
+            echo "Frontend failed (HTTP $STATUS): $BODY" && exit 1
+          fi
 
       - name: Deploy Ollama (B200 GPU)
         run: |
@@ -359,22 +421,25 @@ jobs:
                   pvc: [{
                     path: "/root/.ollama",
                     claimName: $pvc,
-                    size: "50G"
+                    existingPvc: true
                   }]
                 }
               }
             }')
-          RESP=$(curl -fsSL -w "\n%{http_code}" -X POST \
+          RESP=$(curl -sSL -w "\n%{http_code}" -X POST \
             "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $TOKEN" \
             -d "$OLLAMA_JSON") || true
           STATUS=$(echo "$RESP" | tail -1)
           BODY=$(echo "$RESP" | head -n -1)
+          echo "Ollama response (HTTP $STATUS): $BODY"
           if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
             echo "Ollama submitted"
+          elif [ "$STATUS" = "409" ]; then
+            echo "Ollama already exists — skipping"
           else
-            echo "Ollama failed (HTTP $STATUS): $BODY"
+            echo "Ollama failed (HTTP $STATUS): $BODY" && exit 1
           fi
 
       # ── Status ────────────────────────────────────────────────────────────

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,10 +168,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Write VPN config
+        run: echo "${{ secrets.VPN_CONFIG }}" > /tmp/vpn.ovpn
+
       - name: Connect to VPN
         uses: kota65535/github-openvpn-connect-action@v3
         with:
-          config_file: ${{ secrets.VPN_CONFIG }}
+          config_file: /tmp/vpn.ovpn
           username: ${{ secrets.VPN_USERNAME }}
           password: ${{ secrets.VPN_PASSWORD }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -367,4 +367,4 @@ jobs:
         run: |
           curl -fsSL "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads?limit=50" \
             -H "Authorization: Bearer $TOKEN" \
-            | jq '[.[] | select(.name | startswith("medw-")) | {name, phase, clusterName}]'
+            | jq '.workloads // . | if type == "array" then .[] | select(.name | startswith("medw-")) | {name, phase} else . end'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -333,7 +333,7 @@ jobs:
               spec: {
                 image: $image,
                 compute: { cpuCoreRequest: 1, cpuCoreLimit: 1, cpuMemoryRequest: "512M", cpuMemoryLimit: "512M" },
-                ports: [{container: 3000, serviceType: "NodePort"}]
+                ports: [{container: 3000, serviceType: "LoadBalancer"}]
               }
             }')
           RESP=$(curl -sSL -w "\n%{http_code}" -X POST \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,7 +194,7 @@ jobs:
             -H "Accept: */*" \
             -H "Content-Type: application/json" \
             -d "{\"grantType\":\"client_credentials\",\"clientId\":\"$RUNAI_CLIENT_ID\",\"clientSecret\":\"$RUNAI_CLIENT_SECRET\"}" \
-            | jq -r ‘.accessToken’)
+            | jq -r '.accessToken')
 
           if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
             echo "Failed to obtain access token"; exit 1
@@ -206,7 +206,7 @@ jobs:
           PROJECT_RESP=$(curl -fsSL "${{ env.RUNAI_CLUSTER_URL }}/api/v1/org-unit/projects" \
             -H "Authorization: Bearer $TOKEN")
           echo "DEBUG projects response: $PROJECT_RESP"
-          PROJECT_ID=$(echo "$PROJECT_RESP" | jq -r ‘.[] | select(.name == "${{ env.RUNAI_PROJECT }}") | .id’)
+          PROJECT_ID=$(echo "$PROJECT_RESP" | jq -r '.[] | select(.name == "${{ env.RUNAI_PROJECT }}") | .id')
           if [ -z "$PROJECT_ID" ] || [ "$PROJECT_ID" = "null" ]; then
             echo "Failed to find project ${{ env.RUNAI_PROJECT }}"; exit 1
           fi
@@ -242,7 +242,7 @@ jobs:
               --arg projectId "$PROJECT_ID" \
               --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
               --arg pvc "chroma-pvc${SUFFIX}" \
-              ‘{
+              '{
                 name: $name,
                 projectId: $projectId,
                 clusterId: $clusterId,
@@ -264,7 +264,7 @@ jobs:
                     }]
                   }
                 }
-              }’)" && echo "ChromaDB submitted" || echo "ChromaDB submit failed (may already exist)"
+              }')" && echo "ChromaDB submitted" || echo "ChromaDB submit failed (may already exist)"
 
       - name: Deploy Backend
         run: |
@@ -278,7 +278,7 @@ jobs:
               --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
               --arg image "${{ env.REGISTRY }}/${{ env.ORG }}/medw-backend:${TAG}" \
               --arg suffix "$SUFFIX" \
-              ‘{
+              '{
                 name: $name,
                 projectId: $projectId,
                 clusterId: $clusterId,
@@ -294,7 +294,7 @@ jobs:
                   ],
                   ports: [{container: 8000, serviceType: "ClusterIP"}]
                 }
-              }’)" && echo "Backend submitted" || echo "Backend submit failed (may already exist)"
+              }')" && echo "Backend submitted" || echo "Backend submit failed (may already exist)"
 
       - name: Deploy Frontend
         run: |
@@ -307,7 +307,7 @@ jobs:
               --arg projectId "$PROJECT_ID" \
               --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
               --arg image "${{ env.REGISTRY }}/${{ env.ORG }}/medw-frontend:${TAG}" \
-              ‘{
+              '{
                 name: $name,
                 projectId: $projectId,
                 clusterId: $clusterId,
@@ -316,7 +316,7 @@ jobs:
                   compute: { cpuCoreRequest: 1, cpuCoreLimit: 1, cpuMemoryRequest: "512M", cpuMemoryLimit: "512M" },
                   ports: [{container: 3000, serviceType: "NodePort"}]
                 }
-              }’)" && echo "Frontend submitted" || echo "Frontend submit failed (may already exist)"
+              }')" && echo "Frontend submitted" || echo "Frontend submit failed (may already exist)"
 
       - name: Deploy Ollama (B200 GPU)
         run: |
@@ -329,7 +329,7 @@ jobs:
               --arg projectId "$PROJECT_ID" \
               --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
               --arg pvc "ollama-pvc${SUFFIX}" \
-              ‘{
+              '{
                 name: $name,
                 projectId: $projectId,
                 clusterId: $clusterId,
@@ -359,7 +359,7 @@ jobs:
                     }]
                   }
                 }
-              }’)" && echo "Ollama submitted" || echo "Ollama submit failed (may already exist)"
+              }')" && echo "Ollama submitted" || echo "Ollama submit failed (may already exist)"
 
       # ── Status ────────────────────────────────────────────────────────────
       - name: Show workload status
@@ -367,4 +367,4 @@ jobs:
         run: |
           curl -fsSL "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads?limit=50" \
             -H "Authorization: Bearer $TOKEN" \
-            | jq ‘[.[] | select(.name | startswith("medw-")) | {name, phase, clusterName}]’
+            | jq '[.[] | select(.name | startswith("medw-")) | {name, phase, clusterName}]'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -376,8 +376,8 @@ jobs:
                   {name: "OLLAMA_NUM_PARALLEL", value: "4"},
                   {name: "OLLAMA_MAX_LOADED_MODELS", value: "1"}
                 ],
-                command: "/bin/bash",
-                args: "/entrypoint.sh",
+                command: "/bin/sh",
+                args: "-c 'ollama serve & sleep 10 && ollama pull mistral:7b && wait'",
                 ports: [{container: 11434, serviceType: "ClusterIP"}],
                 storage: {
                   pvc: [{

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -235,7 +235,7 @@ jobs:
         run: |
           CHROMA_JSON=$(jq -n \
             --arg name "medw-chromadb${SUFFIX}" \
-            --arg projectId "$PROJECT_ID" \
+            --argjson projectId "$PROJECT_ID" \
             --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
             --arg pvc "chroma-pvc${SUFFIX}" \
             '{
@@ -255,7 +255,6 @@ jobs:
                   pvc: [{
                     path: "/chroma/chroma",
                     claimName: $pvc,
-                    existingPvc: false,
                     size: "10G"
                   }]
                 }
@@ -278,7 +277,7 @@ jobs:
         run: |
           BACKEND_JSON=$(jq -n \
             --arg name "medw-backend${SUFFIX}" \
-            --arg projectId "$PROJECT_ID" \
+            --argjson projectId "$PROJECT_ID" \
             --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
             --arg image "${{ env.REGISTRY }}/${{ env.ORG }}/medw-backend:${TAG}" \
             --arg suffix "$SUFFIX" \
@@ -309,7 +308,7 @@ jobs:
         run: |
           FRONTEND_JSON=$(jq -n \
             --arg name "medw-frontend${SUFFIX}" \
-            --arg projectId "$PROJECT_ID" \
+            --argjson projectId "$PROJECT_ID" \
             --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
             --arg image "${{ env.REGISTRY }}/${{ env.ORG }}/medw-frontend:${TAG}" \
             '{
@@ -332,7 +331,7 @@ jobs:
         run: |
           OLLAMA_JSON=$(jq -n \
             --arg name "medw-ollama${SUFFIX}" \
-            --arg projectId "$PROJECT_ID" \
+            --argjson projectId "$PROJECT_ID" \
             --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
             --arg pvc "ollama-pvc${SUFFIX}" \
             '{
@@ -346,7 +345,7 @@ jobs:
                   cpuMemoryRequest: "32G", cpuMemoryLimit: "32G",
                   gpuDevicesRequest: 1
                 },
-                nodeType: "NVIDIA-B200",
+                nodePools: ["NVIDIA-B200"],
                 environmentVariables: [
                   {name: "OLLAMA_MODEL", value: "mistral:7b"},
                   {name: "OLLAMA_FLASH_ATTENTION", value: "1"},
@@ -354,13 +353,12 @@ jobs:
                   {name: "OLLAMA_MAX_LOADED_MODELS", value: "1"}
                 ],
                 command: "/bin/bash",
-                args: "/entrypoint.sh",
+                args: ["/entrypoint.sh"],
                 ports: [{container: 11434, serviceType: "ClusterIP"}],
                 data: {
                   pvc: [{
                     path: "/root/.ollama",
                     claimName: $pvc,
-                    existingPvc: false,
                     size: "50G"
                   }]
                 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -257,7 +257,7 @@ jobs:
                     path: "/chroma/chroma",
                     claimName: $pvc,
                     existingPvc: false,
-                    size: "10G"
+                    claimInfo: { size: "10Gi" }
                   }]
                 }
               }
@@ -384,7 +384,7 @@ jobs:
                     path: "/root/.ollama",
                     claimName: $pvc,
                     existingPvc: false,
-                    size: "50G"
+                    claimInfo: { size: "50Gi" }
                   }]
                 }
               }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ env:
   ORG: contzokas
   RUNAI_CLUSTER_URL: https://runai.kiefersa.gr
   RUNAI_PROJECT: medo
+  RUNAI_CLUSTER_ID: 0403162b-5439-4561-b986-332482767449
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────
@@ -141,7 +142,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   # ─────────────────────────────────────────────────────────────────────────
-  # Job 3: Deploy via Run:ai CLI
+  # Job 3: Deploy via Run:ai REST API (no CLI needed)
   #
   # Workload names are suffixed by branch:
   #   feature/deploy-to-runai → medw-ollama-test, medw-backend-test, ...
@@ -149,13 +150,9 @@ jobs:
   #   main                    → medw-ollama,       medw-backend,       ...
   #
   # Required secrets (Settings → Secrets → Actions):
-  #   RUNAI_CLIENT_ID     — from https://runai.kiefersa.gr → Settings → Application → New Application
-  #   RUNAI_CLIENT_SECRET — same place (copy the secret immediately, shown only once)
-  #
-  # Why application credentials over API token?
-  #   ✓ Don’t expire (tokens are short-lived JWTs)
-  #   ✓ Designed for non-interactive/CI use
-  #   ✓ Can be scoped to specific permissions
+  #   RUNAI_CLIENT_ID     — from Run:ai → Settings → Application
+  #   RUNAI_CLIENT_SECRET — same place
+  #   VPN_CONFIG / VPN_USERNAME / VPN_PASSWORD — VPN credentials
   # ─────────────────────────────────────────────────────────────────────────
   deploy:
     name: Deploy [${{ needs.setup.outputs.env }}] to Run:ai (medo)
@@ -182,76 +179,39 @@ jobs:
           username: ${{ secrets.VPN_USERNAME }}
           password: ${{ secrets.VPN_PASSWORD }}
 
-      # runai.kiefersa.gr = 10.184.94.250 (private, VPN-only — no DNS push in ovpn)
+      # runai.kiefersa.gr = 10.184.94.250 (private, VPN-only)
       - name: Add Run:ai host entry
         run: echo "10.184.94.250 runai.kiefersa.gr" | sudo tee -a /etc/hosts
 
-      # ── Run:ai CLI ────────────────────────────────────────────────────────
-      - name: Install Run:ai CLI
-        run: |
-          # Get bearer token via client credentials
-          TOKEN=$(curl -fsSL -X POST \
-            "${{ env.RUNAI_CLUSTER_URL }}/auth/realms/runai/protocol/openid-connect/token" \
-            -H "Content-Type: application/x-www-form-urlencoded" \
-            -d "grant_type=client_credentials" \
-            -d "client_id=${{ secrets.RUNAI_CLIENT_ID }}" \
-            -d "client_secret=${{ secrets.RUNAI_CLIENT_SECRET }}" \
-            | jq -r '.access_token')
-
-          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
-            echo "Failed to obtain access token"; exit 1
-          fi
-          echo "Token obtained"
-
-          # Run the official installer script (URL discovered from Run:ai UI)
-          # Respond 'n' to all interactive prompts (PATH, completion, auto-update)
-          printf 'n\nn\nn\n' | bash -c "$(curl -fsSL \
-            "${{ env.RUNAI_CLUSTER_URL }}/api/v1/cli-exposer/installer/linux" \
-            -H "Authorization: Bearer $TOKEN")" || true
-
-          # Installer puts binary at ~/.runai/bin/runai — symlink to system PATH
-          sudo ln -sf /home/runner/.runai/bin/runai /usr/local/bin/runai
-          runai version
-
-      # ── Authenticate ──────────────────────────────────────────────────────
-      - name: Authenticate to Run:ai
+      # ── Auth (REST API, no CLI) ──────────────────────────────────────────
+      - name: Authenticate and resolve project
         env:
           RUNAI_CLIENT_ID:     ${{ secrets.RUNAI_CLIENT_ID }}
           RUNAI_CLIENT_SECRET: ${{ secrets.RUNAI_CLIENT_SECRET }}
         run: |
-          runai config set --cp-url="${{ env.RUNAI_CLUSTER_URL }}"
-
-          # Get bearer token via Run:ai API endpoint (not Keycloak)
           TOKEN=$(curl -fsSL -X POST \
             "${{ env.RUNAI_CLUSTER_URL }}/api/v1/token" \
             -H "Accept: */*" \
             -H "Content-Type: application/json" \
             -d "{\"grantType\":\"client_credentials\",\"clientId\":\"$RUNAI_CLIENT_ID\",\"clientSecret\":\"$RUNAI_CLIENT_SECRET\"}" \
-            | jq -r '.accessToken')
+            | jq -r ‘.accessToken’)
 
           if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
             echo "Failed to obtain access token"; exit 1
           fi
+          echo "TOKEN=$TOKEN" >> "$GITHUB_ENV"
           echo "Token obtained ($(echo -n "$TOKEN" | wc -c) chars)"
 
-          # Write token to authentication.json
-          AUTH_FILE="$HOME/.runai/authentication.json"
-          jq -n --arg token "$TOKEN" \
-            '{access_token: $token, token_type: "Bearer"}' > "$AUTH_FILE"
-          echo "Auth file written"
-          echo "--- auth file contents ---"
-          cat "$AUTH_FILE"
-
-      - name: Set Run:ai cluster and project
-        run: |
-          echo "--- current config ---"
-          cat ~/.runai/config.json
-          echo ""
-          echo "--- trying cluster set ---"
-          runai cluster set runai-kiefer 2>&1 || true
-          echo ""
-          echo "--- trying project set ---"
-          runai project set ${{ env.RUNAI_PROJECT }} 2>&1 || true
+          # Resolve project UUID by name
+          PROJECT_RESP=$(curl -fsSL "${{ env.RUNAI_CLUSTER_URL }}/api/v1/org-unit/projects" \
+            -H "Authorization: Bearer $TOKEN")
+          echo "DEBUG projects response: $PROJECT_RESP"
+          PROJECT_ID=$(echo "$PROJECT_RESP" | jq -r ‘.[] | select(.name == "${{ env.RUNAI_PROJECT }}") | .id’)
+          if [ -z "$PROJECT_ID" ] || [ "$PROJECT_ID" = "null" ]; then
+            echo "Failed to find project ${{ env.RUNAI_PROJECT }}"; exit 1
+          fi
+          echo "PROJECT_ID=$PROJECT_ID" >> "$GITHUB_ENV"
+          echo "Project: ${{ env.RUNAI_PROJECT }} → $PROJECT_ID"
 
       # ── Show plan ─────────────────────────────────────────────────────────
       - name: Show deployment plan
@@ -261,6 +221,8 @@ jobs:
           echo "  Branch      : ${{ github.ref_name }}"
           echo "  Image tag   : ${{ env.TAG }}"
           echo "  Suffix      : ${{ env.SUFFIX }}"
+          echo "  Cluster     : ${{ env.RUNAI_CLUSTER_ID }}"
+          echo "  Project     : ${{ env.RUNAI_PROJECT }} ($PROJECT_ID)"
           echo "  Workloads   :"
           echo "    medw-chromadb${{ env.SUFFIX }}"
           echo "    medw-backend${{ env.SUFFIX }}"
@@ -268,64 +230,141 @@ jobs:
           echo "    medw-ollama${{ env.SUFFIX }}  ← B200 GPU"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-      # ── Submit workloads ──────────────────────────────────────────────────
+      # ── Submit workloads via REST API ────────────────────────────────────
       - name: Deploy ChromaDB
         run: |
-          runai submit medw-chromadb${{ env.SUFFIX }} \
-            --image chromadb/chroma:1.5.7 \
-            --cpu 1 --memory 2G \
-            --project ${{ env.RUNAI_PROJECT }} \
-            -e IS_PERSISTENT=TRUE \
-            -e ANONYMIZED_TELEMETRY=FALSE \
-            -e CHROMA_SERVER_PORT=8000 \
-            --service-type ClusterIP \
-            --port 8000 \
-            --persistent-volume-claim chroma-pvc${{ env.SUFFIX }}:/chroma/chroma \
-            || true
+          curl -fsSL -X POST \
+            "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $TOKEN" \
+            -d "$(jq -n \
+              --arg name "medw-chromadb${SUFFIX}" \
+              --arg projectId "$PROJECT_ID" \
+              --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
+              --arg pvc "chroma-pvc${SUFFIX}" \
+              ‘{
+                name: $name,
+                projectId: $projectId,
+                clusterId: $clusterId,
+                spec: {
+                  image: "chromadb/chroma:1.5.7",
+                  compute: { cpuCoreRequest: 1, cpuCoreLimit: 1, cpuMemoryRequest: "2G", cpuMemoryLimit: "2G" },
+                  environmentVariables: [
+                    {name: "IS_PERSISTENT", value: "TRUE"},
+                    {name: "ANONYMIZED_TELEMETRY", value: "FALSE"},
+                    {name: "CHROMA_SERVER_PORT", value: "8000"}
+                  ],
+                  ports: [{container: 8000, serviceType: "ClusterIP"}],
+                  data: {
+                    pvc: [{
+                      path: "/chroma/chroma",
+                      claimName: $pvc,
+                      existingPvc: false,
+                      size: "10G"
+                    }]
+                  }
+                }
+              }’)" && echo "ChromaDB submitted" || echo "ChromaDB submit failed (may already exist)"
 
       - name: Deploy Backend
         run: |
-          runai submit medw-backend${{ env.SUFFIX }} \
-            --image ${{ env.REGISTRY }}/${{ env.ORG }}/medw-backend:${{ env.TAG }} \
-            --cpu 1 --memory 1G \
-            --project ${{ env.RUNAI_PROJECT }} \
-            -e OLLAMA_HOST=http://medw-ollama${{ env.SUFFIX }}:11434 \
-            -e OLLAMA_MODEL=mistral:7b \
-            -e OLLAMA_TIMEOUT=30 \
-            -e CHROMA_HOST=medw-chromadb${{ env.SUFFIX }} \
-            -e CHROMA_PORT=8000 \
-            --service-type ClusterIP \
-            --port 8000 \
-            || true
+          curl -fsSL -X POST \
+            "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $TOKEN" \
+            -d "$(jq -n \
+              --arg name "medw-backend${SUFFIX}" \
+              --arg projectId "$PROJECT_ID" \
+              --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
+              --arg image "${{ env.REGISTRY }}/${{ env.ORG }}/medw-backend:${TAG}" \
+              --arg suffix "$SUFFIX" \
+              ‘{
+                name: $name,
+                projectId: $projectId,
+                clusterId: $clusterId,
+                spec: {
+                  image: $image,
+                  compute: { cpuCoreRequest: 1, cpuCoreLimit: 1, cpuMemoryRequest: "1G", cpuMemoryLimit: "1G" },
+                  environmentVariables: [
+                    {name: "OLLAMA_HOST", value: ("http://medw-ollama" + $suffix + ":11434")},
+                    {name: "OLLAMA_MODEL", value: "mistral:7b"},
+                    {name: "OLLAMA_TIMEOUT", value: "30"},
+                    {name: "CHROMA_HOST", value: ("medw-chromadb" + $suffix)},
+                    {name: "CHROMA_PORT", value: "8000"}
+                  ],
+                  ports: [{container: 8000, serviceType: "ClusterIP"}]
+                }
+              }’)" && echo "Backend submitted" || echo "Backend submit failed (may already exist)"
 
       - name: Deploy Frontend
         run: |
-          runai submit medw-frontend${{ env.SUFFIX }} \
-            --image ${{ env.REGISTRY }}/${{ env.ORG }}/medw-frontend:${{ env.TAG }} \
-            --cpu 1 --memory 512M \
-            --project ${{ env.RUNAI_PROJECT }} \
-            --service-type NodePort \
-            --port 3000 \
-            || true
+          curl -fsSL -X POST \
+            "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $TOKEN" \
+            -d "$(jq -n \
+              --arg name "medw-frontend${SUFFIX}" \
+              --arg projectId "$PROJECT_ID" \
+              --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
+              --arg image "${{ env.REGISTRY }}/${{ env.ORG }}/medw-frontend:${TAG}" \
+              ‘{
+                name: $name,
+                projectId: $projectId,
+                clusterId: $clusterId,
+                spec: {
+                  image: $image,
+                  compute: { cpuCoreRequest: 1, cpuCoreLimit: 1, cpuMemoryRequest: "512M", cpuMemoryLimit: "512M" },
+                  ports: [{container: 3000, serviceType: "NodePort"}]
+                }
+              }’)" && echo "Frontend submitted" || echo "Frontend submit failed (may already exist)"
 
       - name: Deploy Ollama (B200 GPU)
         run: |
-          runai submit medw-ollama${{ env.SUFFIX }} \
-            --image ollama/ollama:latest \
-            --gpu 1 \
-            --node-type NVIDIA-B200 \
-            --cpu 8 --memory 32G \
-            --project ${{ env.RUNAI_PROJECT }} \
-            -e OLLAMA_MODEL=mistral:7b \
-            -e OLLAMA_FLASH_ATTENTION=1 \
-            -e OLLAMA_NUM_PARALLEL=4 \
-            -e OLLAMA_MAX_LOADED_MODELS=1 \
-            --service-type ClusterIP \
-            --port 11434 \
-            --persistent-volume-claim ollama-pvc${{ env.SUFFIX }}:/root/.ollama \
-            --command -- /bin/bash /entrypoint.sh \
-            || true
+          curl -fsSL -X POST \
+            "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $TOKEN" \
+            -d "$(jq -n \
+              --arg name "medw-ollama${SUFFIX}" \
+              --arg projectId "$PROJECT_ID" \
+              --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
+              --arg pvc "ollama-pvc${SUFFIX}" \
+              ‘{
+                name: $name,
+                projectId: $projectId,
+                clusterId: $clusterId,
+                spec: {
+                  image: "ollama/ollama:latest",
+                  compute: {
+                    cpuCoreRequest: 8, cpuCoreLimit: 8,
+                    cpuMemoryRequest: "32G", cpuMemoryLimit: "32G",
+                    gpuDevicesRequest: 1
+                  },
+                  nodeType: "NVIDIA-B200",
+                  environmentVariables: [
+                    {name: "OLLAMA_MODEL", value: "mistral:7b"},
+                    {name: "OLLAMA_FLASH_ATTENTION", value: "1"},
+                    {name: "OLLAMA_NUM_PARALLEL", value: "4"},
+                    {name: "OLLAMA_MAX_LOADED_MODELS", value: "1"}
+                  ],
+                  command: "/bin/bash",
+                  args: "/entrypoint.sh",
+                  ports: [{container: 11434, serviceType: "ClusterIP"}],
+                  data: {
+                    pvc: [{
+                      path: "/root/.ollama",
+                      claimName: $pvc,
+                      existingPvc: false,
+                      size: "50G"
+                    }]
+                  }
+                }
+              }’)" && echo "Ollama submitted" || echo "Ollama submit failed (may already exist)"
 
+      # ── Status ────────────────────────────────────────────────────────────
       - name: Show workload status
         if: always()
-        run: runai workload list
+        run: |
+          curl -fsSL "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads?limit=50" \
+            -H "Authorization: Bearer $TOKEN" \
+            | jq ‘[.[] | select(.name | startswith("medw-")) | {name, phase, clusterName}]’

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -169,10 +169,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install OpenVPN
-        run: sudo apt-get update -qq && sudo apt-get install -y openvpn
+        run: sudo apt-get update -qq && sudo apt-get install -y openvpn resolvconf
 
       - name: Write VPN config
-        run: echo "${{ secrets.VPN_CONFIG }}" > /tmp/vpn.ovpn
+        run: |
+          echo "${{ secrets.VPN_CONFIG }}" > /tmp/vpn.ovpn
+          # No dhcp-option DNS in this VPN config — hostname resolved via /etc/hosts below
 
       - name: Connect to VPN
         uses: kota65535/github-openvpn-connect-action@v3
@@ -180,6 +182,11 @@ jobs:
           config_file: /tmp/vpn.ovpn
           username: ${{ secrets.VPN_USERNAME }}
           password: ${{ secrets.VPN_PASSWORD }}
+
+      # runai.kiefersa.gr is a private IP (10.184.94.250) only reachable via VPN.
+      # The VPN config doesn't push DNS, so we bypass DNS entirely via /etc/hosts.
+      - name: Add Run:ai host entry
+        run: echo "10.184.94.250 runai.kiefersa.gr" | sudo tee -a /etc/hosts
 
       - name: Install Run:ai CLI
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,256 @@
+name: Build & Deploy to Run:ai
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - feature/deploy-to-runai
+  workflow_dispatch:   # allow manual trigger from any branch in GitHub UI
+
+env:
+  REGISTRY: ghcr.io
+  ORG: contzokas
+  RUNAI_CLUSTER_URL: https://runai.kiefersa.gr
+  RUNAI_PROJECT: medo
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────
+  # Job 0: Resolve branch → image tag + workload suffix
+  #   main                    → tag=latest  suffix=""
+  #   dev                     → tag=dev     suffix="-dev"
+  #   feature/deploy-to-runai → tag=test    suffix="-test"
+  #   any other branch        → tag=test    suffix="-test"
+  # ─────────────────────────────────────────────────────────────────────────
+  setup:
+    name: Resolve deployment environment
+    runs-on: ubuntu-latest
+    outputs:
+      tag:    ${{ steps.resolve.outputs.tag }}
+      suffix: ${{ steps.resolve.outputs.suffix }}
+      env:    ${{ steps.resolve.outputs.env }}
+    steps:
+      - name: Resolve tag and suffix from branch
+        id: resolve
+        run: |
+          BRANCH="${{ github.ref_name }}"
+          echo "Branch: $BRANCH"
+
+          if [ "$BRANCH" = "main" ]; then
+            TAG="latest"
+            SUFFIX=""
+            ENV="production"
+          elif [ "$BRANCH" = "dev" ]; then
+            TAG="dev"
+            SUFFIX="-dev"
+            ENV="development"
+          else
+            TAG="test"
+            SUFFIX="-test"
+            ENV="test"
+          fi
+
+          echo "tag=$TAG"       >> $GITHUB_OUTPUT
+          echo "suffix=$SUFFIX" >> $GITHUB_OUTPUT
+          echo "env=$ENV"       >> $GITHUB_OUTPUT
+
+          echo "──────────────────────────────────"
+          echo "  Branch : $BRANCH"
+          echo "  Tag    : $TAG"
+          echo "  Suffix : ${SUFFIX:-(none)}"
+          echo "  Env    : $ENV"
+          echo "──────────────────────────────────"
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Job 1 & 2: Build images (parallel)
+  # ─────────────────────────────────────────────────────────────────────────
+  build-backend:
+    name: Build backend → :${{ needs.setup.outputs.tag }}
+    runs-on: ubuntu-latest
+    needs: setup
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.ORG }}/medw-backend
+          tags: |
+            type=raw,value=${{ needs.setup.outputs.tag }}
+            type=sha,prefix=${{ needs.setup.outputs.tag }}-,format=short
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-frontend:
+    name: Build frontend → :${{ needs.setup.outputs.tag }}
+    runs-on: ubuntu-latest
+    needs: setup
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.ORG }}/medw-frontend
+          tags: |
+            type=raw,value=${{ needs.setup.outputs.tag }}
+            type=sha,prefix=${{ needs.setup.outputs.tag }}-,format=short
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL || 'http://backend:8000' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Job 3: Deploy via Run:ai CLI
+  #
+  # Workload names are suffixed by branch:
+  #   feature/deploy-to-runai → medw-ollama-test, medw-backend-test, ...
+  #   dev                     → medw-ollama-dev,  medw-backend-dev,  ...
+  #   main                    → medw-ollama,       medw-backend,       ...
+  #
+  # Required secrets (Settings → Secrets → Actions):
+  #   RUNAI_CLIENT_ID     — from https://runai.kiefersa.gr → Settings → Application → New Application
+  #   RUNAI_CLIENT_SECRET — same place (copy the secret immediately, shown only once)
+  #
+  # Why application credentials over API token?
+  #   ✓ Don’t expire (tokens are short-lived JWTs)
+  #   ✓ Designed for non-interactive/CI use
+  #   ✓ Can be scoped to specific permissions
+  # ─────────────────────────────────────────────────────────────────────────
+  deploy:
+    name: Deploy [${{ needs.setup.outputs.env }}] to Run:ai (medo)
+    runs-on: ubuntu-latest
+    needs: [setup, build-backend, build-frontend]
+    environment: ${{ needs.setup.outputs.env }}
+    env:
+      TAG:    ${{ needs.setup.outputs.tag }}
+      SUFFIX: ${{ needs.setup.outputs.suffix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Run:ai CLI
+        run: |
+          curl -L https://github.com/run-ai/runai-cli/releases/latest/download/runai-cli-linux-amd64.tar.gz \
+            | tar xz
+          sudo mv runai /usr/local/bin/runai
+          runai version
+
+      - name: Authenticate to Run:ai (CLI v2)
+        run: |
+          # v2: set control plane URL first, then login via env vars
+          runai config set --cp-url="${{ env.RUNAI_CLUSTER_URL }}"
+          RUNAI_CLIENT_ID="${{ secrets.RUNAI_CLIENT_ID }}" \
+          RUNAI_CLIENT_SECRET="${{ secrets.RUNAI_CLIENT_SECRET }}" \
+          runai login
+
+      - name: Set Run:ai project
+        run: runai project set ${{ env.RUNAI_PROJECT }}
+
+      - name: Show deployment plan
+        run: |
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "  Environment : ${{ needs.setup.outputs.env }}"
+          echo "  Branch      : ${{ github.ref_name }}"
+          echo "  Image tag   : ${{ env.TAG }}"
+          echo "  Suffix      : ${{ env.SUFFIX || '(none — production)' }}"
+          echo "  Workloads   :"
+          echo "    medw-chromadb${{ env.SUFFIX }}"
+          echo "    medw-backend${{ env.SUFFIX }}"
+          echo "    medw-frontend${{ env.SUFFIX }}"
+          echo "    medw-ollama${{ env.SUFFIX }}  ← B200 GPU"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+      - name: Deploy ChromaDB
+        run: |
+          runai submit medw-chromadb${{ env.SUFFIX }} \
+            --image chromadb/chroma:1.5.7 \
+            --cpu 1 --memory 2G \
+            --project ${{ env.RUNAI_PROJECT }} \
+            -e IS_PERSISTENT=TRUE \
+            -e ANONYMIZED_TELEMETRY=FALSE \
+            -e CHROMA_SERVER_PORT=8000 \
+            --service-type ClusterIP \
+            --port 8000 \
+            --persistent-volume-claim chroma-pvc${{ env.SUFFIX }}:/chroma/chroma \
+            || true
+
+      - name: Deploy Backend
+        run: |
+          runai submit medw-backend${{ env.SUFFIX }} \
+            --image ${{ env.REGISTRY }}/${{ env.ORG }}/medw-backend:${{ env.TAG }} \
+            --cpu 1 --memory 1G \
+            --project ${{ env.RUNAI_PROJECT }} \
+            -e OLLAMA_HOST=http://medw-ollama${{ env.SUFFIX }}:11434 \
+            -e OLLAMA_MODEL=mistral:7b \
+            -e OLLAMA_TIMEOUT=30 \
+            -e CHROMA_HOST=medw-chromadb${{ env.SUFFIX }} \
+            -e CHROMA_PORT=8000 \
+            --service-type ClusterIP \
+            --port 8000 \
+            || true
+
+      - name: Deploy Frontend
+        run: |
+          runai submit medw-frontend${{ env.SUFFIX }} \
+            --image ${{ env.REGISTRY }}/${{ env.ORG }}/medw-frontend:${{ env.TAG }} \
+            --cpu 1 --memory 512M \
+            --project ${{ env.RUNAI_PROJECT }} \
+            --service-type NodePort \
+            --port 3000 \
+            || true
+
+      - name: Deploy Ollama (B200 GPU)
+        run: |
+          runai submit medw-ollama${{ env.SUFFIX }} \
+            --image ollama/ollama:latest \
+            --gpu 1 \
+            --node-type NVIDIA-B200 \
+            --cpu 8 --memory 32G \
+            --project ${{ env.RUNAI_PROJECT }} \
+            -e OLLAMA_MODEL=mistral:7b \
+            -e OLLAMA_FLASH_ATTENTION=1 \
+            -e OLLAMA_NUM_PARALLEL=4 \
+            -e OLLAMA_MAX_LOADED_MODELS=1 \
+            --service-type ClusterIP \
+            --port 11434 \
+            --persistent-volume-claim ollama-pvc${{ env.SUFFIX }}:/root/.ollama \
+            --command -- /bin/bash /entrypoint.sh \
+            || true
+
+      - name: Show workload status
+        if: always()
+        run: runai workload list

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -418,7 +418,7 @@ jobs:
                   {name: "OLLAMA_MAX_LOADED_MODELS", value: "1"}
                 ],
                 command: "/bin/bash",
-                args: ["/entrypoint.sh"],
+                args: "/entrypoint.sh",
                 ports: [{container: 11434, serviceType: "ClusterIP"}],
                 storage: {
                   pvc: [{

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -333,7 +333,7 @@ jobs:
               spec: {
                 image: $image,
                 compute: { cpuCoreRequest: 1, cpuCoreLimit: 1, cpuMemoryRequest: "512M", cpuMemoryLimit: "512M" },
-                ports: [{container: 3000, serviceType: "LoadBalancer"}]
+                ports: [{container: 3000, serviceType: "NodePort"}]
               }
             }')
           RESP=$(curl -sSL -w "\n%{http_code}" -X POST \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -236,7 +236,7 @@ jobs:
         run: |
           CHROMA_JSON=$(jq -n \
             --arg name "medw-chromadb${SUFFIX}" \
-            --argjson projectId "$PROJECT_ID" \
+            --arg projectId "$PROJECT_ID" \
             --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
             --arg pvc "chroma-pvc${SUFFIX}" \
             '{
@@ -282,7 +282,7 @@ jobs:
         run: |
           BACKEND_JSON=$(jq -n \
             --arg name "medw-backend${SUFFIX}" \
-            --argjson projectId "$PROJECT_ID" \
+            --arg projectId "$PROJECT_ID" \
             --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
             --arg image "${{ env.REGISTRY }}/${{ env.ORG }}/medw-backend:${TAG}" \
             --arg suffix "$SUFFIX" \
@@ -323,7 +323,7 @@ jobs:
         run: |
           FRONTEND_JSON=$(jq -n \
             --arg name "medw-frontend${SUFFIX}" \
-            --argjson projectId "$PROJECT_ID" \
+            --arg projectId "$PROJECT_ID" \
             --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
             --arg image "${{ env.REGISTRY }}/${{ env.ORG }}/medw-frontend:${TAG}" \
             '{
@@ -356,7 +356,7 @@ jobs:
         run: |
           OLLAMA_JSON=$(jq -n \
             --arg name "medw-ollama${SUFFIX}" \
-            --argjson projectId "$PROJECT_ID" \
+            --arg projectId "$PROJECT_ID" \
             --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
             --arg pvc "ollama-pvc${SUFFIX}" \
             '{

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -221,53 +221,37 @@ jobs:
         run: |
           runai config set --cp-url="${{ env.RUNAI_CLUSTER_URL }}"
 
-          # Get a bearer token via client credentials
+          # Get bearer token via Run:ai API endpoint (not Keycloak)
           TOKEN=$(curl -fsSL -X POST \
-            "${{ env.RUNAI_CLUSTER_URL }}/auth/realms/runai/protocol/openid-connect/token" \
-            -H "Content-Type: application/x-www-form-urlencoded" \
-            -d "grant_type=client_credentials" \
-            -d "client_id=$RUNAI_CLIENT_ID" \
-            -d "client_secret=$RUNAI_CLIENT_SECRET" \
-            | jq -r '.access_token')
+            "${{ env.RUNAI_CLUSTER_URL }}/api/v1/token" \
+            -H "Accept: */*" \
+            -H "Content-Type: application/json" \
+            -d "{\"grantType\":\"client_credentials\",\"clientId\":\"$RUNAI_CLIENT_ID\",\"clientSecret\":\"$RUNAI_CLIENT_SECRET\"}" \
+            | jq -r '.accessToken')
 
           if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
             echo "Failed to obtain access token"; exit 1
           fi
           echo "Token obtained ($(echo -n "$TOKEN" | wc -c) chars)"
 
-          # Write token directly to authentication.json (skip runai login)
+          # Write token to authentication.json
           AUTH_FILE="$HOME/.runai/authentication.json"
           jq -n --arg token "$TOKEN" \
             '{access_token: $token, token_type: "Bearer"}' > "$AUTH_FILE"
-          echo "Auth file written to $AUTH_FILE"
+          echo "Auth file written"
+          echo "--- auth file contents ---"
+          cat "$AUTH_FILE"
 
-      - name: Discover and set Run:ai cluster
-        env:
-          RUNAI_CLIENT_ID:     ${{ secrets.RUNAI_CLIENT_ID }}
-          RUNAI_CLIENT_SECRET: ${{ secrets.RUNAI_CLIENT_SECRET }}
+      - name: Set Run:ai cluster and project
         run: |
-          # List available clusters via API
-          TOKEN=$(curl -fsSL -X POST \
-            "${{ env.RUNAI_CLUSTER_URL }}/auth/realms/runai/protocol/openid-connect/token" \
-            -H "Content-Type: application/x-www-form-urlencoded" \
-            -d "grant_type=client_credentials" \
-            -d "client_id=$RUNAI_CLIENT_ID" \
-            -d "client_secret=$RUNAI_CLIENT_SECRET" \
-            | jq -r '.access_token')
-
-          echo "=== Trying runai cluster list ==="
-          runai cluster list 2>&1 || true
+          echo "--- current config ---"
+          cat ~/.runai/config.json
           echo ""
-
-          echo "=== Trying runai cluster list -o json ==="
-          runai cluster list -o json 2>&1 || true
+          echo "--- trying cluster set ---"
+          runai cluster set runai-kiefer 2>&1 || true
           echo ""
-
-          echo "=== Trying clusters API ==="
-          curl -fsSL "${{ env.RUNAI_CLUSTER_URL }}/api/v1/clusters" \
-            -H "Authorization: Bearer $TOKEN" | jq . 2>&1 || echo "API call failed"
-
-      - name: Set Run:ai project
+          echo "--- trying project set ---"
+          runai project set ${{ env.RUNAI_PROJECT }} 2>&1 || true
         run: runai project set ${{ env.RUNAI_PROJECT }}
 
       # ── Show plan ─────────────────────────────────────────────────────────

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,6 +168,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install OpenVPN
+        run: sudo apt-get update -qq && sudo apt-get install -y openvpn
+
       - name: Write VPN config
         run: echo "${{ secrets.VPN_CONFIG }}" > /tmp/vpn.ovpn
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -233,38 +233,39 @@ jobs:
       # ── Submit workloads via REST API ────────────────────────────────────
       - name: Deploy ChromaDB
         run: |
+          CHROMA_JSON=$(jq -n \
+            --arg name "medw-chromadb${SUFFIX}" \
+            --arg projectId "$PROJECT_ID" \
+            --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
+            --arg pvc "chroma-pvc${SUFFIX}" \
+            '{
+              name: $name,
+              projectId: $projectId,
+              clusterId: $clusterId,
+              spec: {
+                image: "chromadb/chroma:1.5.7",
+                compute: { cpuCoreRequest: 1, cpuCoreLimit: 1, cpuMemoryRequest: "2G", cpuMemoryLimit: "2G" },
+                environmentVariables: [
+                  {name: "IS_PERSISTENT", value: "TRUE"},
+                  {name: "ANONYMIZED_TELEMETRY", value: "FALSE"},
+                  {name: "CHROMA_SERVER_PORT", value: "8000"}
+                ],
+                ports: [{container: 8000, serviceType: "ClusterIP"}],
+                data: {
+                  pvc: [{
+                    path: "/chroma/chroma",
+                    claimName: $pvc,
+                    existingPvc: false,
+                    size: "10G"
+                  }]
+                }
+              }
+            }')
           RESP=$(curl -fsSL -w "\n%{http_code}" -X POST \
             "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $TOKEN" \
-            -d "$(jq -n \
-              --arg name "medw-chromadb${SUFFIX}" \
-              --arg projectId "$PROJECT_ID" \
-              --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
-              --arg pvc "chroma-pvc${SUFFIX}" \
-              '{
-                name: $name,
-                projectId: $projectId,
-                clusterId: $clusterId,
-                spec: {
-                  image: "chromadb/chroma:1.5.7",
-                  compute: { cpuCoreRequest: 1, cpuCoreLimit: 1, cpuMemoryRequest: "2G", cpuMemoryLimit: "2G" },
-                  environmentVariables: [
-                    {name: "IS_PERSISTENT", value: "TRUE"},
-                    {name: "ANONYMIZED_TELEMETRY", value: "FALSE"},
-                    {name: "CHROMA_SERVER_PORT", value: "8000"}
-                  ],
-                  ports: [{container: 8000, serviceType: "ClusterIP"}],
-                  data: {
-                    pvc: [{
-                      path: "/chroma/chroma",
-                      claimName: $pvc,
-                      existingPvc: false,
-                      size: "10G"
-                    }]
-                  }
-                }
-              }")") || true
+            -d "$CHROMA_JSON") || true
           STATUS=$(echo "$RESP" | tail -1)
           BODY=$(echo "$RESP" | head -n -1)
           if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
@@ -275,98 +276,101 @@ jobs:
 
       - name: Deploy Backend
         run: |
+          BACKEND_JSON=$(jq -n \
+            --arg name "medw-backend${SUFFIX}" \
+            --arg projectId "$PROJECT_ID" \
+            --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
+            --arg image "${{ env.REGISTRY }}/${{ env.ORG }}/medw-backend:${TAG}" \
+            --arg suffix "$SUFFIX" \
+            '{
+              name: $name,
+              projectId: $projectId,
+              clusterId: $clusterId,
+              spec: {
+                image: $image,
+                compute: { cpuCoreRequest: 1, cpuCoreLimit: 1, cpuMemoryRequest: "1G", cpuMemoryLimit: "1G" },
+                environmentVariables: [
+                  {name: "OLLAMA_HOST", value: ("http://medw-ollama" + $suffix + ":11434")},
+                  {name: "OLLAMA_MODEL", value: "mistral:7b"},
+                  {name: "OLLAMA_TIMEOUT", value: "30"},
+                  {name: "CHROMA_HOST", value: ("medw-chromadb" + $suffix)},
+                  {name: "CHROMA_PORT", value: "8000"}
+                ],
+                ports: [{container: 8000, serviceType: "ClusterIP"}]
+              }
+            }')
           curl -fsSL -X POST \
             "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $TOKEN" \
-            -d "$(jq -n \
-              --arg name "medw-backend${SUFFIX}" \
-              --arg projectId "$PROJECT_ID" \
-              --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
-              --arg image "${{ env.REGISTRY }}/${{ env.ORG }}/medw-backend:${TAG}" \
-              --arg suffix "$SUFFIX" \
-              '{
-                name: $name,
-                projectId: $projectId,
-                clusterId: $clusterId,
-                spec: {
-                  image: $image,
-                  compute: { cpuCoreRequest: 1, cpuCoreLimit: 1, cpuMemoryRequest: "1G", cpuMemoryLimit: "1G" },
-                  environmentVariables: [
-                    {name: "OLLAMA_HOST", value: ("http://medw-ollama" + $suffix + ":11434")},
-                    {name: "OLLAMA_MODEL", value: "mistral:7b"},
-                    {name: "OLLAMA_TIMEOUT", value: "30"},
-                    {name: "CHROMA_HOST", value: ("medw-chromadb" + $suffix)},
-                    {name: "CHROMA_PORT", value: "8000"}
-                  ],
-                  ports: [{container: 8000, serviceType: "ClusterIP"}]
-                }
-              }')" && echo "Backend submitted" || echo "Backend submit failed (may already exist)"
+            -d "$BACKEND_JSON" && echo "Backend submitted" || echo "Backend submit failed (may already exist)"
 
       - name: Deploy Frontend
         run: |
+          FRONTEND_JSON=$(jq -n \
+            --arg name "medw-frontend${SUFFIX}" \
+            --arg projectId "$PROJECT_ID" \
+            --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
+            --arg image "${{ env.REGISTRY }}/${{ env.ORG }}/medw-frontend:${TAG}" \
+            '{
+              name: $name,
+              projectId: $projectId,
+              clusterId: $clusterId,
+              spec: {
+                image: $image,
+                compute: { cpuCoreRequest: 1, cpuCoreLimit: 1, cpuMemoryRequest: "512M", cpuMemoryLimit: "512M" },
+                ports: [{container: 3000, serviceType: "NodePort"}]
+              }
+            }')
           curl -fsSL -X POST \
             "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $TOKEN" \
-            -d "$(jq -n \
-              --arg name "medw-frontend${SUFFIX}" \
-              --arg projectId "$PROJECT_ID" \
-              --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
-              --arg image "${{ env.REGISTRY }}/${{ env.ORG }}/medw-frontend:${TAG}" \
-              '{
-                name: $name,
-                projectId: $projectId,
-                clusterId: $clusterId,
-                spec: {
-                  image: $image,
-                  compute: { cpuCoreRequest: 1, cpuCoreLimit: 1, cpuMemoryRequest: "512M", cpuMemoryLimit: "512M" },
-                  ports: [{container: 3000, serviceType: "NodePort"}]
-                }
-              }')" && echo "Frontend submitted" || echo "Frontend submit failed (may already exist)"
+            -d "$FRONTEND_JSON" && echo "Frontend submitted" || echo "Frontend submit failed (may already exist)"
 
       - name: Deploy Ollama (B200 GPU)
         run: |
+          OLLAMA_JSON=$(jq -n \
+            --arg name "medw-ollama${SUFFIX}" \
+            --arg projectId "$PROJECT_ID" \
+            --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
+            --arg pvc "ollama-pvc${SUFFIX}" \
+            '{
+              name: $name,
+              projectId: $projectId,
+              clusterId: $clusterId,
+              spec: {
+                image: "ollama/ollama:latest",
+                compute: {
+                  cpuCoreRequest: 8, cpuCoreLimit: 8,
+                  cpuMemoryRequest: "32G", cpuMemoryLimit: "32G",
+                  gpuDevicesRequest: 1
+                },
+                nodeType: "NVIDIA-B200",
+                environmentVariables: [
+                  {name: "OLLAMA_MODEL", value: "mistral:7b"},
+                  {name: "OLLAMA_FLASH_ATTENTION", value: "1"},
+                  {name: "OLLAMA_NUM_PARALLEL", value: "4"},
+                  {name: "OLLAMA_MAX_LOADED_MODELS", value: "1"}
+                ],
+                command: "/bin/bash",
+                args: "/entrypoint.sh",
+                ports: [{container: 11434, serviceType: "ClusterIP"}],
+                data: {
+                  pvc: [{
+                    path: "/root/.ollama",
+                    claimName: $pvc,
+                    existingPvc: false,
+                    size: "50G"
+                  }]
+                }
+              }
+            }')
           RESP=$(curl -fsSL -w "\n%{http_code}" -X POST \
             "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $TOKEN" \
-            -d "$(jq -n \
-              --arg name "medw-ollama${SUFFIX}" \
-              --arg projectId "$PROJECT_ID" \
-              --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
-              --arg pvc "ollama-pvc${SUFFIX}" \
-              '{
-                name: $name,
-                projectId: $projectId,
-                clusterId: $clusterId,
-                spec: {
-                  image: "ollama/ollama:latest",
-                  compute: {
-                    cpuCoreRequest: 8, cpuCoreLimit: 8,
-                    cpuMemoryRequest: "32G", cpuMemoryLimit: "32G",
-                    gpuDevicesRequest: 1
-                  },
-                  nodeType: "NVIDIA-B200",
-                  environmentVariables: [
-                    {name: "OLLAMA_MODEL", value: "mistral:7b"},
-                    {name: "OLLAMA_FLASH_ATTENTION", value: "1"},
-                    {name: "OLLAMA_NUM_PARALLEL", value: "4"},
-                    {name: "OLLAMA_MAX_LOADED_MODELS", value: "1"}
-                  ],
-                  command: "/bin/bash",
-                  args: "/entrypoint.sh",
-                  ports: [{container: 11434, serviceType: "ClusterIP"}],
-                  data: {
-                    pvc: [{
-                      path: "/root/.ollama",
-                      claimName: $pvc,
-                      existingPvc: false,
-                      size: "50G"
-                    }]
-                  }
-                }
-              }")") || true
+            -d "$OLLAMA_JSON") || true
           STATUS=$(echo "$RESP" | tail -1)
           BODY=$(echo "$RESP" | head -n -1)
           if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,6 +231,14 @@ jobs:
           echo "    medw-ollama${{ env.SUFFIX }}  ← B200 GPU"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
+      # ── DEBUG: inspect existing workload to learn correct API field names ─
+      - name: Probe API schema (inspect existing backend workload)
+        run: |
+          echo "=== Listing all medw- workloads ==="
+          curl -sSL "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings?projectId=$PROJECT_ID" \
+            -H "Authorization: Bearer $TOKEN" \
+            | jq '[.entries[]? | select(.name | startswith("medw-")) | {name, spec}]'
+
       # ── Submit workloads via REST API ────────────────────────────────────
       - name: Deploy ChromaDB
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ env:
   RUNAI_CLUSTER_URL: https://runai.kiefersa.gr
   RUNAI_PROJECT: medo
   RUNAI_CLUSTER_ID: 0403162b-5439-4561-b986-332482767449
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true  # suppress Node.js 20 deprecation on all actions
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -359,6 +359,8 @@ jobs:
             --arg projectId "$PROJECT_ID" \
             --arg clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
             --arg pvc "ollama-pvc${SUFFIX}" \
+            --arg cmd "/bin/sh" \
+            --arg cmdargs "-c 'ollama serve & sleep 10 && ollama pull mistral:7b && wait'" \
             '{
               name: $name,
               projectId: $projectId,
@@ -376,8 +378,8 @@ jobs:
                   {name: "OLLAMA_NUM_PARALLEL", value: "4"},
                   {name: "OLLAMA_MAX_LOADED_MODELS", value: "1"}
                 ],
-                command: "/bin/sh",
-                args: "-c 'ollama serve & sleep 10 && ollama pull mistral:7b && wait'",
+                command: $cmd,
+                args: $cmdargs,
                 ports: [{container: 11434, serviceType: "ClusterIP"}],
                 storage: {
                   pvc: [{

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -206,7 +206,7 @@ jobs:
           PROJECT_RESP=$(curl -fsSL "${{ env.RUNAI_CLUSTER_URL }}/api/v1/org-unit/projects" \
             -H "Authorization: Bearer $TOKEN")
           echo "DEBUG projects response: $PROJECT_RESP"
-          PROJECT_ID=$(echo "$PROJECT_RESP" | jq -r '.[] | select(.name == "${{ env.RUNAI_PROJECT }}") | .id')
+          PROJECT_ID=$(echo "$PROJECT_RESP" | jq -r '.projects[] | select(.name == "${{ env.RUNAI_PROJECT }}") | .id')
           if [ -z "$PROJECT_ID" ] || [ "$PROJECT_ID" = "null" ]; then
             echo "Failed to find project ${{ env.RUNAI_PROJECT }}"; exit 1
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -215,22 +215,12 @@ jobs:
 
       # ── Authenticate ──────────────────────────────────────────────────────
       - name: Authenticate to Run:ai (CLI v2)
+        env:
+          RUNAI_CLIENT_ID:     ${{ secrets.RUNAI_CLIENT_ID }}
+          RUNAI_CLIENT_SECRET: ${{ secrets.RUNAI_CLIENT_SECRET }}
         run: |
-          # Get bearer token via client credentials (non-interactive, no browser)
-          TOKEN=$(curl -fsSL -X POST \
-            "${{ env.RUNAI_CLUSTER_URL }}/auth/realms/runai/protocol/openid-connect/token" \
-            -H "Content-Type: application/x-www-form-urlencoded" \
-            -d "grant_type=client_credentials" \
-            -d "client_id=${{ secrets.RUNAI_CLIENT_ID }}" \
-            -d "client_secret=${{ secrets.RUNAI_CLIENT_SECRET }}" \
-            | jq -r '.access_token')
-
-          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
-            echo "Failed to obtain token"; exit 1
-          fi
-
           runai config set --cp-url="${{ env.RUNAI_CLUSTER_URL }}"
-          runai login api-token "$TOKEN"
+          runai login
 
       - name: Set Run:ai project
         run: runai project set ${{ env.RUNAI_PROJECT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -220,7 +220,7 @@ jobs:
           RUNAI_CLIENT_SECRET: ${{ secrets.RUNAI_CLIENT_SECRET }}
         run: |
           runai config set --cp-url="${{ env.RUNAI_CLUSTER_URL }}"
-          runai login
+          runai login --client-id="$RUNAI_CLIENT_ID" --client-secret="$RUNAI_CLIENT_SECRET"
 
       - name: Set Run:ai project
         run: runai project set ${{ env.RUNAI_PROJECT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -233,7 +233,7 @@ jobs:
       # ── Submit workloads via REST API ────────────────────────────────────
       - name: Deploy ChromaDB
         run: |
-          curl -fsSL -X POST \
+          RESP=$(curl -fsSL -w "\n%{http_code}" -X POST \
             "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $TOKEN" \
@@ -264,7 +264,14 @@ jobs:
                     }]
                   }
                 }
-              }')" && echo "ChromaDB submitted" || echo "ChromaDB submit failed (may already exist)"
+              }")") || true
+          STATUS=$(echo "$RESP" | tail -1)
+          BODY=$(echo "$RESP" | head -n -1)
+          if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
+            echo "ChromaDB submitted"
+          else
+            echo "ChromaDB failed (HTTP $STATUS): $BODY"
+          fi
 
       - name: Deploy Backend
         run: |
@@ -320,7 +327,7 @@ jobs:
 
       - name: Deploy Ollama (B200 GPU)
         run: |
-          curl -fsSL -X POST \
+          RESP=$(curl -fsSL -w "\n%{http_code}" -X POST \
             "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $TOKEN" \
@@ -359,7 +366,14 @@ jobs:
                     }]
                   }
                 }
-              }')" && echo "Ollama submitted" || echo "Ollama submit failed (may already exist)"
+              }")") || true
+          STATUS=$(echo "$RESP" | tail -1)
+          BODY=$(echo "$RESP" | head -n -1)
+          if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
+            echo "Ollama submitted"
+          else
+            echo "Ollama failed (HTTP $STATUS): $BODY"
+          fi
 
       # ── Status ────────────────────────────────────────────────────────────
       - name: Show workload status

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,7 +138,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL || 'http://backend:8000' }}
+            NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL || 'http://backend:8000' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -216,10 +216,21 @@ jobs:
       # ── Authenticate ──────────────────────────────────────────────────────
       - name: Authenticate to Run:ai (CLI v2)
         run: |
+          # Get bearer token via client credentials (non-interactive, no browser)
+          TOKEN=$(curl -fsSL -X POST \
+            "${{ env.RUNAI_CLUSTER_URL }}/auth/realms/runai/protocol/openid-connect/token" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "grant_type=client_credentials" \
+            -d "client_id=${{ secrets.RUNAI_CLIENT_ID }}" \
+            -d "client_secret=${{ secrets.RUNAI_CLIENT_SECRET }}" \
+            | jq -r '.access_token')
+
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "Failed to obtain token"; exit 1
+          fi
+
           runai config set --cp-url="${{ env.RUNAI_CLUSTER_URL }}"
-          RUNAI_CLIENT_ID="${{ secrets.RUNAI_CLIENT_ID }}" \
-          RUNAI_CLIENT_SECRET="${{ secrets.RUNAI_CLIENT_SECRET }}" \
-          runai login
+          runai login api-token --token "$TOKEN"
 
       - name: Set Run:ai project
         run: runai project set ${{ env.RUNAI_PROJECT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -230,7 +230,7 @@ jobs:
           fi
 
           runai config set --cp-url="${{ env.RUNAI_CLUSTER_URL }}"
-          runai login api-token --token "$TOKEN"
+          runai login api-token "$TOKEN"
 
       - name: Set Run:ai project
         run: runai project set ${{ env.RUNAI_PROJECT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -252,7 +252,6 @@ jobs:
           echo ""
           echo "--- trying project set ---"
           runai project set ${{ env.RUNAI_PROJECT }} 2>&1 || true
-        run: runai project set ${{ env.RUNAI_PROJECT }}
 
       # ── Show plan ─────────────────────────────────────────────────────────
       - name: Show deployment plan

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,45 +231,6 @@ jobs:
           echo "    medw-ollama${{ env.SUFFIX }}  ← B200 GPU"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-      # ── Provision PVCs (idempotent — 409 = already exists) ──────────────
-      - name: Create PVCs
-        run: |
-          create_pvc() {
-            local pvc_name="$1"
-            local size="$2"
-            local PAYLOAD
-            PAYLOAD=$(jq -n \
-              --arg     name      "$pvc_name" \
-              --argjson projectId "$PROJECT_ID" \
-              --arg     clusterId "${{ env.RUNAI_CLUSTER_ID }}" \
-              --arg     size      "$size" \
-              '{
-                name: $name,
-                projectId: $projectId,
-                clusterId: $clusterId,
-                spec: { size: $size }
-              }')
-            echo "Creating PVC: $pvc_name ($size)"
-            RESP=$(curl -sSL -w "\n%{http_code}" -X POST \
-              "${{ env.RUNAI_CLUSTER_URL }}/api/v1/data-sources/pvcs" \
-              -H "Content-Type: application/json" \
-              -H "Authorization: Bearer $TOKEN" \
-              -d "$PAYLOAD") || true
-            STATUS=$(echo "$RESP" | tail -1)
-            BODY=$(echo "$RESP" | head -n -1)
-            if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
-              echo "  ✓ $pvc_name created"
-            elif [ "$STATUS" = "409" ]; then
-              echo "  ✓ $pvc_name already exists — skipping"
-            else
-              echo "  ✗ $pvc_name failed (HTTP $STATUS): $BODY"
-              exit 1
-            fi
-          }
-
-          create_pvc "chroma-pvc${SUFFIX}" "10G"
-          create_pvc "ollama-pvc${SUFFIX}"  "50G"
-
       # ── Submit workloads via REST API ────────────────────────────────────
       - name: Deploy ChromaDB
         run: |
@@ -295,7 +256,8 @@ jobs:
                   pvc: [{
                     path: "/chroma/chroma",
                     claimName: $pvc,
-                    existingPvc: true
+                    existingPvc: false,
+                    size: "10G"
                   }]
                 }
               }
@@ -422,7 +384,8 @@ jobs:
                   pvc: [{
                     path: "/root/.ollama",
                     claimName: $pvc,
-                    existingPvc: true
+                    existingPvc: false,
+                    size: "50G"
                   }]
                 }
               }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,7 +93,7 @@ jobs:
             type=raw,value=${{ needs.setup.outputs.tag }}
             type=sha,prefix=${{ needs.setup.outputs.tag }}-,format=short
 
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./backend
           file: ./backend/Dockerfile
@@ -130,7 +130,7 @@ jobs:
             type=raw,value=${{ needs.setup.outputs.tag }}
             type=sha,prefix=${{ needs.setup.outputs.tag }}-,format=short
 
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: ./frontend
           file: ./frontend/Dockerfile
@@ -174,7 +174,7 @@ jobs:
         run: echo "${{ secrets.VPN_CONFIG }}" > /tmp/vpn.ovpn
 
       - name: Connect to VPN
-        uses: kota65535/github-openvpn-connect-action@v3
+        uses: kota65535/github-openvpn-connect-action@v3.1.0
         with:
           config_file: /tmp/vpn.ovpn
           username: ${{ secrets.VPN_USERNAME }}
@@ -252,7 +252,7 @@ jobs:
                   {name: "CHROMA_SERVER_PORT", value: "8000"}
                 ],
                 ports: [{container: 8000, serviceType: "ClusterIP"}],
-                data: {
+                storage: {
                   pvc: [{
                     path: "/chroma/chroma",
                     claimName: $pvc,
@@ -380,7 +380,7 @@ jobs:
                 command: "/bin/bash",
                 args: ["/entrypoint.sh"],
                 ports: [{container: 11434, serviceType: "ClusterIP"}],
-                data: {
+                storage: {
                   pvc: [{
                     path: "/root/.ollama",
                     claimName: $pvc,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -219,9 +219,15 @@ jobs:
           RUNAI_CLIENT_ID:     ${{ secrets.RUNAI_CLIENT_ID }}
           RUNAI_CLIENT_SECRET: ${{ secrets.RUNAI_CLIENT_SECRET }}
         run: |
-          runai config set --cp-url="${{ env.RUNAI_CLUSTER_URL }}"
+          # Debug: dump config structure and current config file
+          echo "=== Config generate template ==="
+          runai config generate --json || true
+          echo ""
+          echo "=== Current config file ==="
+          cat ~/.runai/config.json 2>/dev/null || echo "no config file yet"
+          echo ""
 
-          # Get a bearer token via client credentials (non-interactive, no browser)
+          # Get a bearer token via client credentials
           TOKEN=$(curl -fsSL -X POST \
             "${{ env.RUNAI_CLUSTER_URL }}/auth/realms/runai/protocol/openid-connect/token" \
             -H "Content-Type: application/x-www-form-urlencoded" \
@@ -233,10 +239,7 @@ jobs:
           if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
             echo "Failed to obtain access token"; exit 1
           fi
-
-          # Login using username/password flow with the token as password
-          # The CLI needs a user — we use the client_id and token
-          runai login user -u "$RUNAI_CLIENT_ID" -p "$TOKEN"
+          echo "Token obtained ($(echo -n "$TOKEN" | wc -c) chars)"
 
       - name: Set Run:ai project
         run: runai project set ${{ env.RUNAI_PROJECT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -251,6 +251,7 @@ jobs:
                   claimInfo: { size: $size }
                 }
               }')
+            echo "  Payload: $BODY"
             RESP=$(curl -sSL -w "\n%{http_code}" -X POST \
               "${{ env.RUNAI_CLUSTER_URL }}/api/v1/asset/datasource/pvc" \
               -H "Content-Type: application/json" \
@@ -258,12 +259,13 @@ jobs:
               -d "$BODY") || true
             STATUS=$(echo "$RESP" | tail -1)
             BTEXT=$(echo "$RESP" | head -n -1)
+            echo "  PVC $PVC_NAME → HTTP $STATUS: $BTEXT"
             if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ] || [ "$STATUS" = "202" ]; then
-              echo "PVC $PVC_NAME created"
+              echo "  ✓ PVC $PVC_NAME created"
             elif [ "$STATUS" = "409" ]; then
-              echo "PVC $PVC_NAME already exists — skipping"
+              echo "  ✓ PVC $PVC_NAME already exists — skipping"
             else
-              echo "PVC $PVC_NAME failed (HTTP $STATUS): $BTEXT" && exit 1
+              echo "  ✗ PVC $PVC_NAME failed (HTTP $STATUS): $BTEXT" && exit 1
             fi
           }
 
@@ -308,7 +310,7 @@ jobs:
           STATUS=$(echo "$RESP" | tail -1)
           BODY=$(echo "$RESP" | head -n -1)
           echo "ChromaDB response (HTTP $STATUS): $BODY"
-          if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
+          if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ] || [ "$STATUS" = "202" ]; then
             echo "ChromaDB submitted"
           elif [ "$STATUS" = "409" ]; then
             echo "ChromaDB already exists — skipping"
@@ -349,7 +351,7 @@ jobs:
           STATUS=$(echo "$RESP" | tail -1)
           BODY=$(echo "$RESP" | head -n -1)
           echo "Backend response (HTTP $STATUS): $BODY"
-          if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
+          if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ] || [ "$STATUS" = "202" ]; then
             echo "Backend submitted"
           elif [ "$STATUS" = "409" ]; then
             echo "Backend already exists — skipping"
@@ -382,7 +384,7 @@ jobs:
           STATUS=$(echo "$RESP" | tail -1)
           BODY=$(echo "$RESP" | head -n -1)
           echo "Frontend response (HTTP $STATUS): $BODY"
-          if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
+          if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ] || [ "$STATUS" = "202" ]; then
             echo "Frontend submitted"
           elif [ "$STATUS" = "409" ]; then
             echo "Frontend already exists — skipping"
@@ -435,7 +437,7 @@ jobs:
           STATUS=$(echo "$RESP" | tail -1)
           BODY=$(echo "$RESP" | head -n -1)
           echo "Ollama response (HTTP $STATUS): $BODY"
-          if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
+          if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ] || [ "$STATUS" = "202" ]; then
             echo "Ollama submitted"
           elif [ "$STATUS" = "409" ]; then
             echo "Ollama already exists — skipping"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -214,13 +214,29 @@ jobs:
           runai version
 
       # ── Authenticate ──────────────────────────────────────────────────────
-      - name: Authenticate to Run:ai (CLI v2)
+      - name: Authenticate to Run:ai
         env:
           RUNAI_CLIENT_ID:     ${{ secrets.RUNAI_CLIENT_ID }}
           RUNAI_CLIENT_SECRET: ${{ secrets.RUNAI_CLIENT_SECRET }}
         run: |
           runai config set --cp-url="${{ env.RUNAI_CLUSTER_URL }}"
-          runai login --client-id="$RUNAI_CLIENT_ID" --client-secret="$RUNAI_CLIENT_SECRET"
+
+          # Get a bearer token via client credentials (non-interactive, no browser)
+          TOKEN=$(curl -fsSL -X POST \
+            "${{ env.RUNAI_CLUSTER_URL }}/auth/realms/runai/protocol/openid-connect/token" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "grant_type=client_credentials" \
+            -d "client_id=$RUNAI_CLIENT_ID" \
+            -d "client_secret=$RUNAI_CLIENT_SECRET" \
+            | jq -r '.access_token')
+
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "Failed to obtain access token"; exit 1
+          fi
+
+          # Login using username/password flow with the token as password
+          # The CLI needs a user — we use the client_id and token
+          runai login user -u "$RUNAI_CLIENT_ID" -p "$TOKEN"
 
       - name: Set Run:ai project
         run: runai project set ${{ env.RUNAI_PROJECT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,13 +231,45 @@ jobs:
           echo "    medw-ollama${{ env.SUFFIX }}  ← B200 GPU"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-      # ── DEBUG: inspect existing workload to learn correct API field names ─
-      - name: Probe API schema (inspect existing backend workload)
+      # ── Create PVCs via Run:ai asset API (idempotent) ──────────────────
+      - name: Create PVCs
         run: |
-          echo "=== Listing all medw- workloads ==="
-          curl -sSL "${{ env.RUNAI_CLUSTER_URL }}/api/v1/workloads/trainings?projectId=$PROJECT_ID" \
-            -H "Authorization: Bearer $TOKEN" \
-            | jq '[.entries[]? | select(.name | startswith("medw-")) | {name, spec}]'
+          create_pvc() {
+            local PVC_NAME="$1"
+            local SIZE="$2"
+            local BODY
+            BODY=$(jq -n \
+              --arg name    "$PVC_NAME" \
+              --argjson pid  "$PROJECT_ID" \
+              --arg cid     "${{ env.RUNAI_CLUSTER_ID }}" \
+              --arg size    "$SIZE" \
+              '{
+                meta: { name: $name, projectId: $pid, clusterId: $cid },
+                spec: {
+                  claimName:   $name,
+                  existingPvc: false,
+                  size:        $size,
+                  accessModes: { readWriteOnce: true }
+                }
+              }')
+            RESP=$(curl -sSL -w "\n%{http_code}" -X POST \
+              "${{ env.RUNAI_CLUSTER_URL }}/api/v1/asset/pvc" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer $TOKEN" \
+              -d "$BODY") || true
+            STATUS=$(echo "$RESP" | tail -1)
+            BTEXT=$(echo  "$RESP" | head -n -1)
+            if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
+              echo "PVC $PVC_NAME created"
+            elif [ "$STATUS" = "409" ]; then
+              echo "PVC $PVC_NAME already exists — skipping"
+            else
+              echo "PVC $PVC_NAME failed (HTTP $STATUS): $BTEXT" && exit 1
+            fi
+          }
+
+          create_pvc "chroma-pvc${SUFFIX}" "10G"
+          create_pvc "ollama-pvc${SUFFIX}"  "50G"
 
       # ── Submit workloads via REST API ────────────────────────────────────
       - name: Deploy ChromaDB
@@ -264,8 +296,7 @@ jobs:
                   pvc: [{
                     path: "/chroma/chroma",
                     claimName: $pvc,
-                    existingPvc: false,
-                    size: "10G"
+                    existingPvc: true
                   }]
                 }
               }
@@ -392,8 +423,7 @@ jobs:
                   pvc: [{
                     path: "/root/.ollama",
                     claimName: $pvc,
-                    existingPvc: false,
-                    size: "50G"
+                    existingPvc: true
                   }]
                 }
               }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,13 +168,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # ── VPN ───────────────────────────────────────────────────────────────
       - name: Install OpenVPN
         run: sudo apt-get update -qq && sudo apt-get install -y openvpn resolvconf
 
       - name: Write VPN config
-        run: |
-          echo "${{ secrets.VPN_CONFIG }}" > /tmp/vpn.ovpn
-          # No dhcp-option DNS in this VPN config — hostname resolved via /etc/hosts below
+        run: echo "${{ secrets.VPN_CONFIG }}" > /tmp/vpn.ovpn
 
       - name: Connect to VPN
         uses: kota65535/github-openvpn-connect-action@v3
@@ -183,14 +182,14 @@ jobs:
           username: ${{ secrets.VPN_USERNAME }}
           password: ${{ secrets.VPN_PASSWORD }}
 
-      # runai.kiefersa.gr is a private IP (10.184.94.250) only reachable via VPN.
-      # The VPN config doesn't push DNS, so we bypass DNS entirely via /etc/hosts.
+      # runai.kiefersa.gr = 10.184.94.250 (private, VPN-only — no DNS push in ovpn)
       - name: Add Run:ai host entry
         run: echo "10.184.94.250 runai.kiefersa.gr" | sudo tee -a /etc/hosts
 
+      # ── Run:ai CLI ────────────────────────────────────────────────────────
       - name: Install Run:ai CLI
         run: |
-          # Step 1: get a bearer token via client credentials
+          # Get bearer token via client credentials
           TOKEN=$(curl -fsSL -X POST \
             "${{ env.RUNAI_CLUSTER_URL }}/auth/realms/runai/protocol/openid-connect/token" \
             -H "Content-Type: application/x-www-form-urlencoded" \
@@ -200,23 +199,20 @@ jobs:
             | jq -r '.access_token')
 
           if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
-            echo "Failed to obtain access token"
-            exit 1
+            echo "Failed to obtain access token"; exit 1
           fi
-          echo "Token obtained successfully"
+          echo "Token obtained"
 
-          # Step 2: download CLI using the token
-          curl -fsSL \
-            -H "Authorization: Bearer $TOKEN" \
-            "${{ env.RUNAI_CLUSTER_URL }}/api/v1/cli/linux" -o runai
+          # Run the official installer script (URL discovered from Run:ai UI)
+          bash -c "$(curl -fsSL \
+            "${{ env.RUNAI_CLUSTER_URL }}/api/v1/cli-exposer/installer/linux" \
+            -H "Authorization: Bearer $TOKEN")"
 
-          chmod +x runai
-          sudo mv runai /usr/local/bin/runai
           runai version
 
+      # ── Authenticate ──────────────────────────────────────────────────────
       - name: Authenticate to Run:ai (CLI v2)
         run: |
-          # v2: set control plane URL first, then login via env vars
           runai config set --cp-url="${{ env.RUNAI_CLUSTER_URL }}"
           RUNAI_CLIENT_ID="${{ secrets.RUNAI_CLIENT_ID }}" \
           RUNAI_CLIENT_SECRET="${{ secrets.RUNAI_CLIENT_SECRET }}" \
@@ -225,13 +221,14 @@ jobs:
       - name: Set Run:ai project
         run: runai project set ${{ env.RUNAI_PROJECT }}
 
+      # ── Show plan ─────────────────────────────────────────────────────────
       - name: Show deployment plan
         run: |
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo "  Environment : ${{ needs.setup.outputs.env }}"
           echo "  Branch      : ${{ github.ref_name }}"
           echo "  Image tag   : ${{ env.TAG }}"
-          echo "  Suffix      : ${{ env.SUFFIX || '(none — production)' }}"
+          echo "  Suffix      : ${{ env.SUFFIX }}"
           echo "  Workloads   :"
           echo "    medw-chromadb${{ env.SUFFIX }}"
           echo "    medw-backend${{ env.SUFFIX }}"
@@ -239,6 +236,7 @@ jobs:
           echo "    medw-ollama${{ env.SUFFIX }}  ← B200 GPU"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
+      # ── Submit workloads ──────────────────────────────────────────────────
       - name: Deploy ChromaDB
         run: |
           runai submit medw-chromadb${{ env.SUFFIX }} \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -239,27 +239,26 @@ jobs:
             local SIZE="$2"
             local BODY
             BODY=$(jq -n \
-              --arg name    "$PVC_NAME" \
-              --argjson pid  "$PROJECT_ID" \
-              --arg cid     "${{ env.RUNAI_CLUSTER_ID }}" \
-              --arg size    "$SIZE" \
+              --arg name "$PVC_NAME" \
+              --argjson pid "$PROJECT_ID" \
+              --arg size "$SIZE" \
               '{
-                meta: { name: $name, projectId: $pid, clusterId: $cid },
+                meta: { name: $name, scope: "project", projectId: $pid },
                 spec: {
-                  claimName:   $name,
+                  path: "/data",
+                  claimName: $name,
                   existingPvc: false,
-                  size:        $size,
-                  accessModes: { readWriteOnce: true }
+                  claimInfo: { size: $size }
                 }
               }')
             RESP=$(curl -sSL -w "\n%{http_code}" -X POST \
-              "${{ env.RUNAI_CLUSTER_URL }}/api/v1/asset/pvc" \
+              "${{ env.RUNAI_CLUSTER_URL }}/api/v1/asset/datasource/pvc" \
               -H "Content-Type: application/json" \
               -H "Authorization: Bearer $TOKEN" \
               -d "$BODY") || true
             STATUS=$(echo "$RESP" | tail -1)
-            BTEXT=$(echo  "$RESP" | head -n -1)
-            if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ]; then
+            BTEXT=$(echo "$RESP" | head -n -1)
+            if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ] || [ "$STATUS" = "202" ]; then
               echo "PVC $PVC_NAME created"
             elif [ "$STATUS" = "409" ]; then
               echo "PVC $PVC_NAME already exists — skipping"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -370,7 +370,6 @@ jobs:
                   cpuMemoryRequest: "32G", cpuMemoryLimit: "32G",
                   gpuDevicesRequest: 1
                 },
-                nodePools: ["NVIDIA-B200"],
                 environmentVariables: [
                   {name: "OLLAMA_MODEL", value: "mistral:7b"},
                   {name: "OLLAMA_FLASH_ATTENTION", value: "1"},

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -219,13 +219,7 @@ jobs:
           RUNAI_CLIENT_ID:     ${{ secrets.RUNAI_CLIENT_ID }}
           RUNAI_CLIENT_SECRET: ${{ secrets.RUNAI_CLIENT_SECRET }}
         run: |
-          # Debug: dump config structure and current config file
-          echo "=== Config generate template ==="
-          runai config generate --json || true
-          echo ""
-          echo "=== Current config file ==="
-          cat ~/.runai/config.json 2>/dev/null || echo "no config file yet"
-          echo ""
+          runai config set --cp-url="${{ env.RUNAI_CLUSTER_URL }}"
 
           # Get a bearer token via client credentials
           TOKEN=$(curl -fsSL -X POST \
@@ -240,6 +234,38 @@ jobs:
             echo "Failed to obtain access token"; exit 1
           fi
           echo "Token obtained ($(echo -n "$TOKEN" | wc -c) chars)"
+
+          # Write token directly to authentication.json (skip runai login)
+          AUTH_FILE="$HOME/.runai/authentication.json"
+          jq -n --arg token "$TOKEN" \
+            '{access_token: $token, token_type: "Bearer"}' > "$AUTH_FILE"
+          echo "Auth file written to $AUTH_FILE"
+
+      - name: Discover and set Run:ai cluster
+        env:
+          RUNAI_CLIENT_ID:     ${{ secrets.RUNAI_CLIENT_ID }}
+          RUNAI_CLIENT_SECRET: ${{ secrets.RUNAI_CLIENT_SECRET }}
+        run: |
+          # List available clusters via API
+          TOKEN=$(curl -fsSL -X POST \
+            "${{ env.RUNAI_CLUSTER_URL }}/auth/realms/runai/protocol/openid-connect/token" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "grant_type=client_credentials" \
+            -d "client_id=$RUNAI_CLIENT_ID" \
+            -d "client_secret=$RUNAI_CLIENT_SECRET" \
+            | jq -r '.access_token')
+
+          echo "=== Trying runai cluster list ==="
+          runai cluster list 2>&1 || true
+          echo ""
+
+          echo "=== Trying runai cluster list -o json ==="
+          runai cluster list -o json 2>&1 || true
+          echo ""
+
+          echo "=== Trying clusters API ==="
+          curl -fsSL "${{ env.RUNAI_CLUSTER_URL }}/api/v1/clusters" \
+            -H "Authorization: Bearer $TOKEN" | jq . 2>&1 || echo "API call failed"
 
       - name: Set Run:ai project
         run: runai project set ${{ env.RUNAI_PROJECT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -190,8 +190,26 @@ jobs:
 
       - name: Install Run:ai CLI
         run: |
-          # Download CLI directly from the Run:ai platform (official method)
-          curl -fsSL "${{ env.RUNAI_CLUSTER_URL }}/api/v1/cli/linux" -o runai
+          # Step 1: get a bearer token via client credentials
+          TOKEN=$(curl -fsSL -X POST \
+            "${{ env.RUNAI_CLUSTER_URL }}/auth/realms/runai/protocol/openid-connect/token" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "grant_type=client_credentials" \
+            -d "client_id=${{ secrets.RUNAI_CLIENT_ID }}" \
+            -d "client_secret=${{ secrets.RUNAI_CLIENT_SECRET }}" \
+            | jq -r '.access_token')
+
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "Failed to obtain access token"
+            exit 1
+          fi
+          echo "Token obtained successfully"
+
+          # Step 2: download CLI using the token
+          curl -fsSL \
+            -H "Authorization: Bearer $TOKEN" \
+            "${{ env.RUNAI_CLUSTER_URL }}/api/v1/cli/linux" -o runai
+
           chmod +x runai
           sudo mv runai /usr/local/bin/runai
           runai version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,47 +231,6 @@ jobs:
           echo "    medw-ollama${{ env.SUFFIX }}  ← B200 GPU"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-      # ── Create PVCs via Run:ai asset API (idempotent) ──────────────────
-      - name: Create PVCs
-        run: |
-          create_pvc() {
-            local PVC_NAME="$1"
-            local SIZE="$2"
-            local BODY
-            BODY=$(jq -n \
-              --arg name "$PVC_NAME" \
-              --argjson pid "$PROJECT_ID" \
-              --arg size "$SIZE" \
-              '{
-                meta: { name: $name, scope: "project", projectId: $pid },
-                spec: {
-                  path: "/data",
-                  claimName: $name,
-                  existingPvc: false,
-                  claimInfo: { size: $size }
-                }
-              }')
-            echo "  Payload: $BODY"
-            RESP=$(curl -sSL -w "\n%{http_code}" -X POST \
-              "${{ env.RUNAI_CLUSTER_URL }}/api/v1/asset/datasource/pvc" \
-              -H "Content-Type: application/json" \
-              -H "Authorization: Bearer $TOKEN" \
-              -d "$BODY") || true
-            STATUS=$(echo "$RESP" | tail -1)
-            BTEXT=$(echo "$RESP" | head -n -1)
-            echo "  PVC $PVC_NAME → HTTP $STATUS: $BTEXT"
-            if [ "$STATUS" = "200" ] || [ "$STATUS" = "201" ] || [ "$STATUS" = "202" ]; then
-              echo "  ✓ PVC $PVC_NAME created"
-            elif [ "$STATUS" = "409" ]; then
-              echo "  ✓ PVC $PVC_NAME already exists — skipping"
-            else
-              echo "  ✗ PVC $PVC_NAME failed (HTTP $STATUS): $BTEXT" && exit 1
-            fi
-          }
-
-          create_pvc "chroma-pvc${SUFFIX}" "10G"
-          create_pvc "ollama-pvc${SUFFIX}"  "50G"
-
       # ── Submit workloads via REST API ────────────────────────────────────
       - name: Deploy ChromaDB
         run: |
@@ -297,7 +256,8 @@ jobs:
                   pvc: [{
                     path: "/chroma/chroma",
                     claimName: $pvc,
-                    existingPvc: true
+                    existingPvc: false,
+                    size: "10G"
                   }]
                 }
               }
@@ -424,7 +384,8 @@ jobs:
                   pvc: [{
                     path: "/root/.ollama",
                     claimName: $pvc,
-                    existingPvc: true
+                    existingPvc: false,
+                    size: "50G"
                   }]
                 }
               }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -204,10 +204,13 @@ jobs:
           echo "Token obtained"
 
           # Run the official installer script (URL discovered from Run:ai UI)
-          bash -c "$(curl -fsSL \
+          # Respond 'n' to all interactive prompts (PATH, completion, auto-update)
+          printf 'n\nn\nn\n' | bash -c "$(curl -fsSL \
             "${{ env.RUNAI_CLUSTER_URL }}/api/v1/cli-exposer/installer/linux" \
-            -H "Authorization: Bearer $TOKEN")"
+            -H "Authorization: Bearer $TOKEN")" || true
 
+          # Installer puts binary at ~/.runai/bin/runai — symlink to system PATH
+          sudo ln -sf /home/runner/.runai/bin/runai /usr/local/bin/runai
           runai version
 
       # ── Authenticate ──────────────────────────────────────────────────────

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -368,15 +368,15 @@ jobs:
               spec: {
                 image: "ollama/ollama:latest",
                 compute: {
-                  cpuCoreRequest: 8, cpuCoreLimit: 8,
-                  cpuMemoryRequest: "32G", cpuMemoryLimit: "32G",
-                  gpuDevicesRequest: 1
+                  cpuCoreRequest: 24, cpuCoreLimit: 24,
+                  cpuMemoryRequest: "96G", cpuMemoryLimit: "96G",
+                  gpuDevicesRequest: 3
                 },
                 environmentVariables: [
                   {name: "OLLAMA_MODEL", value: "mistral:7b"},
                   {name: "OLLAMA_FLASH_ATTENTION", value: "1"},
-                  {name: "OLLAMA_NUM_PARALLEL", value: "4"},
-                  {name: "OLLAMA_MAX_LOADED_MODELS", value: "1"}
+                  {name: "OLLAMA_NUM_PARALLEL", value: "12"},
+                  {name: "OLLAMA_MAX_LOADED_MODELS", value: "3"}
                 ],
                 command: $cmd,
                 args: $cmdargs,

--- a/README.md
+++ b/README.md
@@ -161,6 +161,82 @@ Full project documentation is in [`docs/`](docs/):
 
 ---
 
+## Run:ai Deployment (NVIDIA GPU — Kubernetes)
+
+For production / cluster deployment on a Run:ai-managed Kubernetes cluster.
+
+### Prerequisites
+
+- `kubectl` configured against your cluster
+- Run:ai project `medw` with ≥ 1 GPU quota
+- Images pushed to GHCR (done automatically by the CI pipeline on push to `main`)
+
+### One-command deploy
+
+```bash
+kubectl apply -k k8s/
+```
+
+This creates the `medw` namespace and deploys all four services in the correct order.
+
+### Check status
+
+```bash
+# All pods
+kubectl get pods -n medw -o wide
+
+# GPU allocation via Run:ai CLI
+runai list jobs -p medw
+
+# Logs
+kubectl logs -n medw deployment/medw-ollama -f
+kubectl logs -n medw deployment/medw-backend -f
+```
+
+### Access the app
+
+```bash
+# Frontend (patient triage + nurse dashboard)
+kubectl port-forward -n medw svc/frontend 3000:3000
+# → http://localhost:3000
+
+# Backend API / Swagger
+kubectl port-forward -n medw svc/backend 8000:8000
+# → http://localhost:8000/docs
+
+# Ollama directly (optional debugging)
+kubectl port-forward -n medw svc/ollama 11434:11434
+# → curl http://localhost:11434/api/tags
+```
+
+### CI/CD
+
+Push to `main` automatically builds & pushes images to `ghcr.io/medw/` and
+re-deploys the cluster. Requires one repository secret:
+
+| Secret | Value |
+|---|---|
+| `KUBECONFIG` | base64-encoded kubeconfig for the cluster |
+| `NEXT_PUBLIC_API_URL` | *(optional)* external backend URL if using Ingress |
+
+Add secrets at **Settings → Secrets and variables → Actions**.
+
+### Manifest structure
+
+```
+k8s/
+├── namespace.yaml                  # medw namespace
+├── pvcs.yaml                       # ollama-pvc (20Gi) + chroma-pvc (5Gi)
+├── configmap-ollama-entrypoint.yaml
+├── ollama-deployment.yaml          # GPU workload (runai-scheduler, nvidia.com/gpu: 1)
+├── chromadb-deployment.yaml
+├── backend-deployment.yaml
+├── frontend-deployment.yaml
+└── kustomization.yaml              # kubectl apply -k k8s/
+```
+
+---
+
 ## License
 
 Apache 2.0

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,0 +1,177 @@
+# deploy.ps1 — Manual build + deploy to Run:ai cluster
+# Cluster:  runai-kiefer
+# Project:  medo  (namespace: runai-medo)
+#
+# Run from the root of the MedW repo:  .\deploy.ps1
+#
+# Prerequisites:
+#   - Docker Desktop running
+#   - Run:ai CLI installed  (https://github.com/run-ai/runai-cli/releases)
+#   - Logged in: runai login --cluster-url <url> --token <token>
+#   - Logged in to image registry: docker login ghcr.io
+
+param(
+    [string]$Registry     = "ghcr.io/medw",
+    [string]$Tag          = "test",                    # test | dev | latest
+    [string]$Suffix       = "-test",                   # workload name suffix
+    [string]$ClusterUrl   = "https://runai.kiefersa.gr",
+    [string]$ClientId     = "",   # Run:ai Application Client ID
+    [string]$ClientSecret = "",   # Run:ai Application Client Secret
+    [switch]$SkipBuild    = $false,
+    [switch]$SkipPush     = $false,
+    [switch]$SkipLogin    = $false  # use if already logged in via 'runai login'
+)
+
+$ErrorActionPreference = "Stop"
+$Project = "medo"
+
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "  MedW — Run:ai Deployment Script"       -ForegroundColor Cyan
+Write-Host "  Cluster: runai-kiefer | Project: medo" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ""
+
+# ── 0. Login to Run:ai CLI (v2 syntax) ────────────────────────────────────────────
+# Run:ai CLI v2 uses environment variables for non-interactive auth:
+#   $env:RUNAI_CLIENT_ID     = "<client-id>"
+#   $env:RUNAI_CLIENT_SECRET = "<client-secret>"
+#   runai login
+#
+# Control plane URL must be set first (one-time per machine):
+#   runai config set --cp-url=https://runai.kiefersa.gr
+if (-not $SkipLogin) {
+    Write-Host "[0] Configuring Run:ai CLI..." -ForegroundColor Yellow
+
+    # Set control plane URL (safe to run every time)
+    runai config set --cp-url=$ClusterUrl
+    if ($LASTEXITCODE -ne 0) { throw "Failed to set Run:ai control plane URL" }
+
+    if ($ClientId -and $ClientSecret) {
+        Write-Host "    Logging in with application credentials..." -ForegroundColor Yellow
+        $env:RUNAI_CLIENT_ID     = $ClientId
+        $env:RUNAI_CLIENT_SECRET = $ClientSecret
+        runai login
+        if ($LASTEXITCODE -ne 0) { throw "Run:ai login failed" }
+    } else {
+        Write-Host "    No credentials provided — assuming already logged in." -ForegroundColor DarkGray
+        Write-Host "    To login: set RUNAI_CLIENT_ID + RUNAI_CLIENT_SECRET, then: runai login" -ForegroundColor DarkGray
+    }
+
+    # v2: use 'runai project set' (not 'runai config project')
+    runai project set $Project
+    Write-Host "  ✓ Project set to '$Project'" -ForegroundColor Green
+}
+
+# ── 1. Build images ──────────────────────────────────────────────────────────
+if (-not $SkipBuild) {
+    Write-Host ""
+    Write-Host "[1/4] Building backend image..." -ForegroundColor Yellow
+    docker build -t "$Registry/medw-backend:$Tag" ./backend
+    if ($LASTEXITCODE -ne 0) { throw "Backend build failed" }
+
+    Write-Host "[1/4] Building frontend image..." -ForegroundColor Yellow
+    docker build `
+        --build-arg NEXT_PUBLIC_API_URL="http://backend:8000" `
+        -t "$Registry/medw-frontend:$Tag" `
+        ./frontend
+    if ($LASTEXITCODE -ne 0) { throw "Frontend build failed" }
+
+    Write-Host "  ✓ Images built" -ForegroundColor Green
+} else {
+    Write-Host "[1/4] Skipping image build (-SkipBuild)" -ForegroundColor DarkGray
+}
+
+# ── 2. Push images ───────────────────────────────────────────────────────────
+if (-not $SkipPush) {
+    Write-Host ""
+    Write-Host "[2/4] Pushing images to $Registry ..." -ForegroundColor Yellow
+    docker push "$Registry/medw-backend:$Tag"
+    if ($LASTEXITCODE -ne 0) { throw "Backend push failed" }
+    docker push "$Registry/medw-frontend:$Tag"
+    if ($LASTEXITCODE -ne 0) { throw "Frontend push failed" }
+    Write-Host "  ✓ Images pushed" -ForegroundColor Green
+} else {
+    Write-Host "[2/4] Skipping image push (-SkipPush)" -ForegroundColor DarkGray
+}
+
+# ── 3. Submit workloads via Run:ai CLI ───────────────────────────────────────
+# No kubeconfig needed — Run:ai CLI uses token auth.
+Write-Host ""
+Write-Host "[3/4] Submitting workloads to Run:ai (project: $Project)..." -ForegroundColor Yellow
+
+# ChromaDB — CPU only
+Write-Host "  → ChromaDB..."
+runai submit medw-chromadb `
+    --image chromadb/chroma:1.5.7 `
+    --cpu 1 --memory 2G `
+    --project $Project `
+    -e IS_PERSISTENT=TRUE `
+    -e ANONYMIZED_TELEMETRY=FALSE `
+    -e CHROMA_SERVER_PORT=8000 `
+    --service-type ClusterIP `
+    --port 8000 `
+    --persistent-volume-claim chroma-pvc:/chroma/chroma
+
+# Backend — CPU only
+Write-Host "  → Backend..."
+runai submit medw-backend `
+    --image "$Registry/medw-backend:$Tag" `
+    --cpu 1 --memory 1G `
+    --project $Project `
+    -e OLLAMA_HOST=http://medw-ollama:11434 `
+    -e OLLAMA_MODEL=mistral:7b `
+    -e OLLAMA_TIMEOUT=30 `
+    -e CHROMA_HOST=medw-chromadb `
+    -e CHROMA_PORT=8000 `
+    --service-type ClusterIP `
+    --port 8000
+
+# Frontend — CPU only
+Write-Host "  → Frontend..."
+runai submit medw-frontend `
+    --image "$Registry/medw-frontend:$Tag" `
+    --cpu 1 --memory 512M `
+    --project $Project `
+    --service-type NodePort `
+    --port 3000
+
+# Ollama — 1x NVIDIA B200 GPU
+Write-Host "  → Ollama (B200 GPU)..."
+runai submit medw-ollama `
+    --image ollama/ollama:latest `
+    --gpu 1 `
+    --node-type NVIDIA-B200 `
+    --cpu 8 --memory 32G `
+    --project $Project `
+    -e OLLAMA_MODEL=mistral:7b `
+    -e OLLAMA_FLASH_ATTENTION=1 `
+    -e OLLAMA_NUM_PARALLEL=4 `
+    -e OLLAMA_MAX_LOADED_MODELS=1 `
+    --service-type ClusterIP `
+    --port 11434 `
+    --persistent-volume-claim ollama-pvc:/root/.ollama `
+    --command -- /bin/bash /entrypoint.sh
+
+Write-Host "  ✓ All workloads submitted" -ForegroundColor Green
+
+# ── 4. Status ────────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "[4/4] Workload status:" -ForegroundColor Yellow
+runai list workloads -p $Project
+
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Green
+Write-Host "  Deployment submitted!" -ForegroundColor Green
+Write-Host "========================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "Monitor GPU workload:"
+Write-Host "  runai logs medw-ollama$Suffix -p $Project -f" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Access the app (once pods are Running):"
+Write-Host "  runai port-forward medw-frontend$Suffix --ports 3000:3000 -p $Project" -ForegroundColor Cyan
+Write-Host "  runai port-forward medw-backend$Suffix  --ports 8000:8000 -p $Project" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "List workloads (v2 command):"
+Write-Host "  runai workload list" -ForegroundColor Cyan
+Write-Host ""

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: medw-backend
+  namespace: runai-medo
+  labels:
+    app: medw-backend
+    app.kubernetes.io/part-of: medw
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: medw-backend
+  template:
+    metadata:
+      labels:
+        app: medw-backend
+    spec:
+      containers:
+        - name: backend
+          # Replace with your actual GHCR image after CI builds it:
+          # ghcr.io/medw/medw-backend:latest
+          image: ghcr.io/medw/medw-backend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: OLLAMA_HOST
+              value: "http://ollama:11434"
+            - name: OLLAMA_MODEL
+              value: "mistral:7b"
+            - name: OLLAMA_TIMEOUT
+              value: "30"
+            - name: CHROMA_HOST
+              value: "chromadb"
+            - name: CHROMA_PORT
+              value: "8000"
+            - name: QUEUE_MAX_ENTRIES
+              value: "1000"
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "1"
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: medw
+  labels:
+    app: medw-backend
+    app.kubernetes.io/part-of: medw
+spec:
+  selector:
+    app: medw-backend
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+  type: ClusterIP

--- a/k8s/chromadb-deployment.yaml
+++ b/k8s/chromadb-deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: medw-chromadb
+  namespace: runai-medo
+  labels:
+    app: medw-chromadb
+    app.kubernetes.io/part-of: medw
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: medw-chromadb
+  template:
+    metadata:
+      labels:
+        app: medw-chromadb
+    spec:
+      containers:
+        - name: chromadb
+          image: chromadb/chroma:1.5.7
+          ports:
+            - containerPort: 8000
+              name: chroma-api
+          env:
+            - name: IS_PERSISTENT
+              value: "TRUE"
+            - name: ANONYMIZED_TELEMETRY
+              value: "FALSE"
+            - name: CHROMA_SERVER_PORT
+              value: "8000"
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "1"
+          readinessProbe:
+            httpGet:
+              path: /api/v1/heartbeat
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/v1/heartbeat
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          volumeMounts:
+            - name: chroma-data
+              mountPath: /chroma/chroma
+      volumes:
+        - name: chroma-data
+          persistentVolumeClaim:
+            claimName: chroma-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chromadb
+  namespace: medw
+  labels:
+    app: medw-chromadb
+    app.kubernetes.io/part-of: medw
+spec:
+  selector:
+    app: medw-chromadb
+  ports:
+    - name: chroma-api
+      port: 8000
+      targetPort: 8000
+  type: ClusterIP

--- a/k8s/configmap-ollama-entrypoint.yaml
+++ b/k8s/configmap-ollama-entrypoint.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ollama-entrypoint
+  namespace: runai-medo
+  labels:
+    app.kubernetes.io/part-of: medw
+data:
+  ollama-entrypoint.sh: |
+    #!/bin/bash
+    set -e
+
+    echo "Starting Ollama server..."
+    ollama serve &
+    OLLAMA_PID=$!
+
+    echo "Waiting for Ollama API to be ready..."
+    until ollama list 2>/dev/null || ! kill -0 $OLLAMA_PID 2>/dev/null; do
+      sleep 2
+    done
+
+    if ! kill -0 $OLLAMA_PID 2>/dev/null; then
+        echo "Ollama server crashed."
+        exit 1
+    fi
+
+    echo "Ollama API ready."
+
+    OLLAMA_MODEL="${OLLAMA_MODEL:-mistral:7b}"
+
+    echo "Pulling ${OLLAMA_MODEL} model (this may take several minutes on first run)..."
+    ollama pull "${OLLAMA_MODEL}"
+
+    echo "Verifying ${OLLAMA_MODEL} is present..."
+    until ollama list | grep -q "${OLLAMA_MODEL}" || ! kill -0 $OLLAMA_PID 2>/dev/null; do
+      echo "  ${OLLAMA_MODEL} not confirmed yet, retrying..."
+      sleep 5
+    done
+
+    if ! kill -0 $OLLAMA_PID 2>/dev/null; then
+        echo "Ollama server crashed."
+        exit 1
+    fi
+
+    echo "${OLLAMA_MODEL} loaded and ready."
+    wait $OLLAMA_PID

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: medw-frontend
+  namespace: runai-medo
+  labels:
+    app: medw-frontend
+    app.kubernetes.io/part-of: medw
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: medw-frontend
+  template:
+    metadata:
+      labels:
+        app: medw-frontend
+    spec:
+      containers:
+        - name: frontend
+          # Replace with your actual GHCR image after CI builds it:
+          # ghcr.io/medw/medw-frontend:latest
+          image: ghcr.io/medw/medw-frontend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+              name: http
+          env:
+            # NEXT_PUBLIC_API_URL is baked at build time (see CI workflow).
+            # At runtime this env var is informational only, but we set it
+            # consistently in case the app reads it server-side.
+            - name: NEXT_PUBLIC_API_URL
+              value: "http://backend:8000"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: runai-medo
+  labels:
+    app: medw-frontend
+    app.kubernetes.io/part-of: medw
+spec:
+  selector:
+    app: medw-frontend
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+      # nodePort is auto-assigned; pin it here (30000–32767) if you need a stable port:
+      # nodePort: 30300
+  type: NodePort   # exposes the frontend on every cluster node's IP

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Run:ai project "medo" on cluster "runai-kiefer"
+# Namespace follows Run:ai convention: runai-<project-name>
+namespace: runai-medo
+
+resources:
+  - namespace.yaml
+  - pvcs.yaml
+  - configmap-ollama-entrypoint.yaml
+  - ollama-deployment.yaml
+  - chromadb-deployment.yaml
+  - backend-deployment.yaml
+  - frontend-deployment.yaml

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: runai-medo
+  labels:
+    app.kubernetes.io/name: medw
+    runai/queue: medo        # ties this namespace to the Run:ai project "medo"

--- a/k8s/ollama-deployment.yaml
+++ b/k8s/ollama-deployment.yaml
@@ -1,0 +1,140 @@
+# Ollama — GPU workload (Run:ai scheduled) — NVIDIA B200 (Blackwell)
+#
+# Cluster:  runai-kiefer
+# Project:  medo
+# Namespace: runai-medo  (Run:ai convention: runai-<project>)
+#
+# Targeting: NVIDIA B200 (Blackwell, 192 GB HBM3e)
+# CUDA requirement: 12.8+ — satisfied by ollama/ollama:latest (Ollama >= 0.3.x)
+#
+# Run:ai scheduling is enabled via:
+#   - schedulerName: runai-scheduler
+#   - resources.limits: nvidia.com/gpu: 1
+#   - nodeSelector: nvidia.com/gpu.product: NVIDIA-B200
+#
+# The Run:ai project "medo" must have at least 1 GPU quota assigned.
+#
+# B200 capability notes:
+#   - 192 GB HBM3e GPU memory → can run 70B+ parameter models comfortably
+#   - Default model: mistral:7b (change OLLAMA_MODEL to e.g. llama3:70b for more power)
+#   - NVLink 5 bandwidth: 1.8 TB/s — ideal for large context windows
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: medw-ollama
+  namespace: runai-medo
+  labels:
+    app: medw-ollama
+    app.kubernetes.io/part-of: medw
+    gpu-type: b200
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: medw-ollama
+  template:
+    metadata:
+      labels:
+        app: medw-ollama
+        gpu-type: b200
+      annotations:
+        # Run:ai: request 1 full B200 GPU from the "medo" project quota
+        # on cluster "runai-kiefer".
+        scheduling.run.ai/fraction: "1"
+        # Pin to B200 node pool — set to your Run:ai node pool name if configured:
+        # scheduling.run.ai/node-pool: "b200"
+    spec:
+      schedulerName: runai-scheduler   # ← hand scheduling to Run:ai
+
+      # ── Pin to B200 nodes ───────────────────────────────────────────────────
+      # Kubernetes labels the GPU product automatically via the NVIDIA device plugin.
+      # Run: kubectl get nodes -o json | jq '.items[].metadata.labels' to confirm.
+      nodeSelector:
+        nvidia.com/gpu.product: NVIDIA-B200
+
+      # Tolerate any taint that may be set on GPU nodes (common cluster practice)
+      tolerations:
+        - key: "nvidia.com/gpu"
+          operator: "Exists"
+          effect: "NoSchedule"
+
+      containers:
+        - name: ollama
+          # ollama:latest includes CUDA 12.8 support required for Blackwell (B200)
+          image: ollama/ollama:latest
+          command: ["/bin/bash", "/entrypoint.sh"]
+          ports:
+            - containerPort: 11434
+              name: ollama-api
+          env:
+            - name: OLLAMA_MODEL
+              value: "mistral:7b"
+              # ↑ B200 can handle much larger models. Options:
+              #   mistral:7b   — fast, default (~4 GB VRAM)
+              #   llama3:8b    — good quality (~5 GB VRAM)
+              #   llama3:70b   — high quality (~40 GB VRAM, still fits in B200's 192 GB)
+              #   mixtral:8x7b — MoE, excellent for multilingual (Greek) (~26 GB VRAM)
+
+            # B200 Blackwell FP8 acceleration — Ollama uses this automatically
+            - name: OLLAMA_FLASH_ATTENTION
+              value: "1"
+            - name: OLLAMA_NUM_PARALLEL
+              value: "4"   # serve up to 4 concurrent triage requests on B200
+            - name: OLLAMA_MAX_LOADED_MODELS
+              value: "1"
+
+          resources:
+            requests:
+              memory: "32Gi"   # system RAM request — B200 nodes typically have 1-2 TB RAM
+              cpu: "8"
+            limits:
+              memory: "64Gi"
+              cpu: "16"
+              nvidia.com/gpu: 1    # 1 × B200 (192 GB HBM3e)
+
+          readinessProbe:
+            exec:
+              command: ["ollama", "list"]
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 40   # ~10 min tolerance for first-run model pull
+          livenessProbe:
+            exec:
+              command: ["ollama", "list"]
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            failureThreshold: 5
+
+          volumeMounts:
+            - name: ollama-data
+              mountPath: /root/.ollama
+            - name: entrypoint
+              mountPath: /entrypoint.sh
+              subPath: ollama-entrypoint.sh
+
+      volumes:
+        - name: ollama-data
+          persistentVolumeClaim:
+            claimName: ollama-pvc
+        - name: entrypoint
+          configMap:
+            name: ollama-entrypoint
+            defaultMode: 0755
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+  namespace: runai-medo
+  labels:
+    app: medw-ollama
+    app.kubernetes.io/part-of: medw
+spec:
+  selector:
+    app: medw-ollama
+  ports:
+    - name: ollama-api
+      port: 11434
+      targetPort: 11434
+  type: ClusterIP   # internal only — backend reaches it as http://ollama:11434

--- a/k8s/pvcs.yaml
+++ b/k8s/pvcs.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-pvc
+  namespace: runai-medo
+  labels:
+    app.kubernetes.io/part-of: medw
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi   # mistral:7b ~4 GB; room for additional models
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: chroma-pvc
+  namespace: runai-medo
+  labels:
+    app.kubernetes.io/part-of: medw
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">GitHub Actions Workflow</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><a href="vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/.github/workflows/deploy.yml" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">.github/workflows/deploy.yml</a></strong> — the single workflow file, triggered on push to <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">main</code>, <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">dev</code>, or <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">feature/deploy-to-runai</code>. It runs <strong>5 jobs</strong>:</p>
Job | What it does
-- | --
setup | Resolves branch → image tag (latest/dev/test) and workload name suffix
build-backend | Builds & pushes ghcr.io/contzokas/medw-backend Docker image
build-frontend | Builds & pushes ghcr.io/contzokas/medw-frontend Docker image
deploy | Connects via VPN, authenticates to Run:ai REST API, submits 4 workloads

<hr style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Docker Build Inputs (used by the build jobs)</h2><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong><a href="vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/backend/Dockerfile" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">backend/Dockerfile</a></strong><span> </span>— Python 3.11-slim, runs<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">uvicorn</code></li><li><strong><a href="vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/frontend/Dockerfile" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">frontend/Dockerfile</a></strong><span> </span>— Node 20-alpine, builds Next.js, accepts<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NEXT_PUBLIC_API_URL</code><span> </span>as a build arg</li></ul><hr style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Kubernetes Manifests (referenced but NOT applied by the workflow)</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">k8s/</code> directory contains static K8s manifests that are <strong>not used</strong> by the current GitHub Actions workflow — the workflow deploys directly via the Run:ai REST API instead (inline JSON in each <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">curl</code> step). These manifests appear to be an earlier or alternative approach:</p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><a href="vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/k8s/namespace.yaml" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">k8s/namespace.yaml</a></li><li><a href="vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/k8s/pvcs.yaml" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">k8s/pvcs.yaml</a></li><li><a href="vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/k8s/ollama-deployment.yaml" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">k8s/ollama-deployment.yaml</a></li><li><a href="vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/k8s/chromadb-deployment.yaml" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">k8s/chromadb-deployment.yaml</a></li><li><a href="vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/k8s/backend-deployment.yaml" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">k8s/backend-deployment.yaml</a></li><li><a href="vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/k8s/frontend-deployment.yaml" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">k8s/frontend-deployment.yaml</a></li><li><a href="vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/k8s/kustomization.yaml" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">k8s/kustomization.yaml</a></li></ul><hr style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Local Dev (not part of CI/CD)</h2><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong><a href="vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/docker-compose.yml" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">docker-compose.yml</a></strong><span> </span>— used locally only, not referenced by the workflow</li></ul><hr style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>In short:</strong> the live deployment pipeline only touches <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">deploy.yml</code> + the two <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Dockerfile</code>s. The <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">k8s/</code> manifests exist as static reference but are bypassed in favour of the REST API approach.</p><!--EndFragment-->
</body>
</html>GitHub Actions Workflow
[.github/workflows/deploy.yml](vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/.github/workflows/deploy.yml) — the single workflow file, triggered on push to main, dev, or feature/deploy-to-runai. It runs 5 jobs:

Job	What it does
setup	Resolves branch → image tag (latest/dev/test) and workload name suffix
build-backend	Builds & pushes ghcr.io/contzokas/medw-backend Docker image
build-frontend	Builds & pushes ghcr.io/contzokas/medw-frontend Docker image
deploy	Connects via VPN, authenticates to Run:ai REST API, submits 4 workloads
Docker Build Inputs (used by the build jobs)
[backend/Dockerfile](vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/backend/Dockerfile) — Python 3.11-slim, runs uvicorn
[frontend/Dockerfile](vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/frontend/Dockerfile) — Node 20-alpine, builds Next.js, accepts NEXT_PUBLIC_API_URL as a build arg
Kubernetes Manifests (referenced but NOT applied by the workflow)
The k8s/ directory contains static K8s manifests that are not used by the current GitHub Actions workflow — the workflow deploys directly via the Run:ai REST API instead (inline JSON in each curl step). These manifests appear to be an earlier or alternative approach:

[k8s/namespace.yaml](vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/k8s/namespace.yaml)
[k8s/pvcs.yaml](vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/k8s/pvcs.yaml)
[k8s/ollama-deployment.yaml](vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/k8s/ollama-deployment.yaml)
[k8s/chromadb-deployment.yaml](vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/k8s/chromadb-deployment.yaml)
[k8s/backend-deployment.yaml](vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/k8s/backend-deployment.yaml)
[k8s/frontend-deployment.yaml](vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/k8s/frontend-deployment.yaml)
[k8s/kustomization.yaml](vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/k8s/kustomization.yaml)
Local Dev (not part of CI/CD)
[docker-compose.yml](vscode-webview://18jp9k04iqifm06u21sqi285bgil0ma9j6j16jngpfd08rt6d6j0/docker-compose.yml) — used locally only, not referenced by the workflow
In short: the live deployment pipeline only touches deploy.yml + the two Dockerfiles. The k8s/ manifests exist as static reference but are bypassed in favour of the REST API approach.