### PR TITLE
feat(frontend): management dashboard, doctors portal, and UX overhaul

### DIFF
--- a/frontend/app/components/DoctorsLink.tsx
+++ b/frontend/app/components/DoctorsLink.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+
+export default function DoctorsLink() {
+  const pathname = usePathname()
+  if (pathname === "/management") return null
+
+  return (
+    <Link
+      href="/doctors"
+      className="theme-toggle-btn h-11 px-3 rounded-full flex items-center justify-center border border-border/50 bg-card/60 backdrop-blur-md shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 transition-colors hover:bg-card/80"
+      aria-label="Doctors Dashboard"
+    >
+      <svg className="w-4 h-4 text-foreground/70 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+      </svg>
+      <span className="text-xs font-bold tracking-widest text-muted-foreground">DOCTORS</span>
+    </Link>
+  )
+}

--- a/frontend/app/components/HistoryToggle.tsx
+++ b/frontend/app/components/HistoryToggle.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { useSearchParams, useRouter, usePathname } from "next/navigation"
+import { useCallback } from "react"
+
+export default function HistoryToggle() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname()
+  const active = searchParams.get("history") === "1"
+
+  const toggle = useCallback(() => {
+    if (pathname !== "/") {
+      router.push(active ? "/" : "/?history=1")
+      return
+    }
+    const params = new URLSearchParams(searchParams.toString())
+    if (active) {
+      params.delete("history")
+    } else {
+      params.set("history", "1")
+    }
+    const qs = params.toString()
+    router.push(qs ? `/?${qs}` : "/")
+  }, [active, router, pathname, searchParams])
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={active ? "Back to assessment" : "View history"}
+      title={active ? "Back to assessment" : "View history"}
+      className={`theme-toggle-btn w-11 h-11 rounded-full flex items-center justify-center border transition-all ${
+        active
+          ? "border-primary/30 bg-primary/10"
+          : "border-border/50 bg-card/60 backdrop-blur-md shadow-lg"
+      } focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60`}
+    >
+      <svg className={`w-[18px] h-[18px] transition-colors ${active ? "text-primary" : "text-foreground/70"}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+      </svg>
+    </button>
+  )
+}

--- a/frontend/app/components/ManagementLink.tsx
+++ b/frontend/app/components/ManagementLink.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import Link from "next/link"
+
+export default function ManagementLink() {
+  return (
+    <Link
+      href="/management"
+      aria-label="Management Dashboard"
+      className="theme-toggle-btn w-11 h-11 rounded-full flex items-center justify-center border border-border/50 bg-card/60 backdrop-blur-md shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 transition-colors hover:bg-card/80"
+    >
+      <svg
+        className="w-[18px] h-[18px] text-foreground/70"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={1.8}
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z"
+        />
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z"
+        />
+      </svg>
+    </Link>
+  )
+}

--- a/frontend/app/components/SettingsPanel.tsx
+++ b/frontend/app/components/SettingsPanel.tsx
@@ -85,7 +85,7 @@ export default function SettingsPanel() {
           <p className="text-[10px] font-bold tracking-[0.2em] text-muted-foreground mb-3">
             {t.settings.theme}
           </p>
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-2 gap-3">
             <button
               type="button"
               onClick={() => setTheme("light")}
@@ -127,27 +127,6 @@ export default function SettingsPanel() {
                 <path strokeLinecap="round" strokeLinejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
               </svg>
               {t.settings.dark}
-            </button>
-            <button
-              type="button"
-              onClick={() => setTheme("system")}
-              className={`rounded-xl border-2 px-4 py-3 text-sm font-semibold tracking-wide transition-colors ${
-                theme === "system"
-                  ? "border-primary bg-primary/5 text-primary"
-                  : "border-border/50 bg-card/60 text-muted-foreground hover:border-border"
-              }`}
-            >
-              <svg
-                className="w-5 h-5 mx-auto mb-1.5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={1.8}
-                aria-hidden="true"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25A2.25 2.25 0 0 1 5.25 3h13.5A2.25 2.25 0 0 1 21 5.25Z" />
-              </svg>
-              {t.settings.system}
             </button>
           </div>
         </section>

--- a/frontend/app/components/SymptomWizard.tsx
+++ b/frontend/app/components/SymptomWizard.tsx
@@ -11,20 +11,23 @@ import {
   DURATION_OPTIONS,
   type BodyArea,
   type SeverityOption,
-  type DurationOption,
 } from "@/app/lib/wizard-data"
 
 type WizardStep = "body-area" | "symptoms" | "severity" | "duration" | "review"
 
 const STEPS: WizardStep[] = ["body-area", "symptoms", "severity", "duration", "review"]
 
+const STEP_LABELS: Record<WizardStep, { en: string; el: string }> = {
+  "body-area": { en: "Body Area", el: "Περιοχή" },
+  "symptoms": { en: "Symptoms", el: "Συμπτώματα" },
+  "severity": { en: "Severity", el: "Σοβαρότητα" },
+  "duration": { en: "Duration", el: "Διάρκεια" },
+  "review": { en: "Review", el: "Έλεγχος" },
+}
+
 function generatePatientId(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    try {
-      return crypto.randomUUID()
-    } catch {
-      /* insecure context */
-    }
+    try { return crypto.randomUUID() } catch { /* */ }
   }
   return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
     const r = (Math.random() * 16) | 0
@@ -57,6 +60,14 @@ interface SymptomWizardProps {
   longitude: number | null
 }
 
+const CARD_BASE = "rounded-2xl border-2 p-5 cursor-pointer transition-all duration-200"
+
+const SEVERITY_GRADIENTS: Record<string, string> = {
+  mild: "hover:border-green-400 hover:bg-green-50/30 dark:hover:bg-green-950/20",
+  moderate: "hover:border-yellow-400 hover:bg-yellow-50/30 dark:hover:bg-yellow-950/20",
+  severe: "hover:border-red-400 hover:bg-red-50/30 dark:hover:bg-red-950/20",
+}
+
 export default function SymptomWizard({ patientId, onResult, onStartLoading, latitude, longitude }: SymptomWizardProps) {
   const { t, lang } = useLang()
 
@@ -76,16 +87,12 @@ export default function SymptomWizard({ patientId, onResult, onStartLoading, lat
 
   function goBack() {
     const idx = currentStepIndex - 1
-    if (idx >= 0) {
-      setState((prev) => ({ ...prev, step: STEPS[idx] }))
-    }
+    if (idx >= 0) setState((prev) => ({ ...prev, step: STEPS[idx] }))
   }
 
   function goNext() {
     const idx = currentStepIndex + 1
-    if (idx < STEPS.length) {
-      setState((prev) => ({ ...prev, step: STEPS[idx] }))
-    }
+    if (idx < STEPS.length) setState((prev) => ({ ...prev, step: STEPS[idx] }))
   }
 
   function toggleSymptom(symptomId: string) {
@@ -104,24 +111,16 @@ export default function SymptomWizard({ patientId, onResult, onStartLoading, lat
       .filter(Boolean)
       .map((s) => localizedLabel(s!, lang))
       .join(", ")
-
     const severityOption = SEVERITY_OPTIONS.find((s) => s.id === state.severity)
     const severityLabel = severityOption ? localizedLabel(severityOption, lang) : ""
-
     const durationOption = DURATION_OPTIONS.find((d) => d.id === state.duration)
     const durationLabel = durationOption ? localizedLabel(durationOption, lang) : ""
 
-    let text: string
-    if (lang === "el") {
-      text = `Έχω ${symptomLabels} στην περιοχή ${areaLabel}. Σοβαρότητα: ${severityLabel}. Διάρκεια: ${durationLabel}.`
-    } else {
-      text = `I have ${symptomLabels} in the ${areaLabel} area. Severity: ${severityLabel}. Duration: ${durationLabel}.`
-    }
+    let text = lang === "el"
+      ? `Έχω ${symptomLabels} στην περιοχή ${areaLabel}. Σοβαρότητα: ${severityLabel}. Διάρκεια: ${durationLabel}.`
+      : `I have ${symptomLabels} in the ${areaLabel} area. Severity: ${severityLabel}. Duration: ${durationLabel}.`
 
-    if (state.additionalNotes.trim()) {
-      text += ` ${state.additionalNotes.trim()}`
-    }
-
+    if (state.additionalNotes.trim()) text += ` ${state.additionalNotes.trim()}`
     return text
   }
 
@@ -130,13 +129,11 @@ export default function SymptomWizard({ patientId, onResult, onStartLoading, lat
     setIsLoading(true)
     setError(null)
     onStartLoading?.()
-
     try {
       const symptoms = buildSymptomsString()
       const result = await submitTriage(symptoms, patientId ?? generatePatientId(), lang, 0, "", false, latitude, longitude)
       onResult(result as TriageResponse)
-    } catch (err) {
-      console.error("[SymptomWizard] submit error:", err)
+    } catch {
       setError(t.form.error)
     } finally {
       setIsLoading(false)
@@ -145,314 +142,287 @@ export default function SymptomWizard({ patientId, onResult, onStartLoading, lat
 
   const canProceed = (() => {
     switch (state.step) {
-      case "body-area":
-        return state.selectedArea !== null
-      case "symptoms":
-        return state.selectedSymptoms.length > 0
-      case "severity":
-        return state.severity !== null
-      case "duration":
-        return state.duration !== null
-      case "review":
-        return true
+      case "body-area": return state.selectedArea !== null
+      case "symptoms": return state.selectedSymptoms.length > 0
+      case "severity": return state.severity !== null
+      case "duration": return state.duration !== null
+      case "review": return true
     }
   })()
 
   function handleNext() {
-    if (state.step === "review") {
-      handleSubmit()
-      return
-    }
-
+    if (state.step === "review") { handleSubmit(); return }
     if (state.step === "symptoms" && state.selectedSymptoms.length === 0) {
-      setError(t.wizard.atLeastOne)
-      return
+      setError(t.wizard.atLeastOne); return
     }
-
     setError(null)
     goNext()
   }
 
-  // ── Step indicator ──
   function renderStepIndicator() {
     return (
-      <div className="mb-6">
-        <div className="flex items-center justify-between mb-2">
-          <p className="text-[10px] font-bold tracking-[0.2em] text-muted-foreground">
-            {toCaps(t.wizard.step, lang)} {currentStepIndex + 1} {t.wizard.of} {STEPS.length}
-          </p>
-        </div>
-        <div className="w-full h-1.5 rounded-full bg-border overflow-hidden">
-          <div
-            className="h-full rounded-full bg-primary transition-all duration-300"
-            style={{ width: `${((currentStepIndex + 1) / STEPS.length) * 100}%` }}
-          />
+      <div className="mb-8">
+        <div className="flex gap-0.5">
+          {STEPS.map((step, i) => {
+            const isCompleted = i < currentStepIndex
+            const isCurrent = i === currentStepIndex
+            const label = STEP_LABELS[step]
+            const stepLabel = lang === "el" ? label.el : label.en
+            return (
+              <div key={step} className="flex-1 flex flex-col items-center gap-1.5">
+                <div className={`w-full h-2 ${
+                  i === 0 ? "rounded-l-full" : i === STEPS.length - 1 ? "rounded-r-full" : ""
+                } ${
+                  isCompleted || isCurrent ? "bg-primary" : "bg-muted"
+                } ${
+                  isCurrent ? "ring-2 ring-primary/20" : ""
+                } transition-all duration-300`} />
+                <span className={`text-[9px] font-semibold text-center leading-tight transition-colors ${
+                  isCurrent ? "text-primary" : isCompleted ? "text-foreground/70" : "text-muted-foreground/60"
+                }`}>
+                  {stepLabel}
+                </span>
+              </div>
+            )
+          })}
         </div>
       </div>
     )
   }
 
-  // ── Step 1: Body area ──
   function renderBodyAreaStep() {
     return (
       <div>
-        <h2 className="text-lg font-semibold text-foreground mb-4">
-          {t.wizard.bodyAreaTitle}
+        <h2 className="text-base font-bold text-foreground mb-4 flex items-center gap-2">
+          <span className="text-xl">📍</span> {t.wizard.bodyAreaTitle}
         </h2>
-        <div className="grid grid-cols-2 gap-3">
-          {BODY_AREAS.map((area) => (
-            <button
-              key={area.id}
-              type="button"
-              onClick={() =>
-                setState((prev) => ({
-                  ...prev,
-                  selectedArea: area,
-                  selectedSymptoms: [],
-                }))
-              }
-              className={`rounded-xl border-2 p-4 cursor-pointer text-left transition-all duration-150 ${
-                state.selectedArea?.id === area.id
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary/40 bg-card"
-              }`}
-            >
-              <span className="text-2xl" role="img" aria-hidden="true">
-                {area.icon}
-              </span>
-              <p className="mt-2 text-sm font-medium text-foreground">
-                {localizedLabel(area, lang)}
-              </p>
-              <p className="mt-0.5 text-[11px] text-muted-foreground">
-                {area.symptoms.length}{" "}
-                {lang === "el" ? "συμπτώματα" : "symptoms"}
-              </p>
-            </button>
-          ))}
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+          {BODY_AREAS.map((area) => {
+            const selected = state.selectedArea?.id === area.id
+            return (
+              <button
+                key={area.id}
+                type="button"
+                onClick={() => setState((prev) => ({ ...prev, selectedArea: area, selectedSymptoms: [] }))}
+                className={`${CARD_BASE} text-center group ${
+                  selected
+                    ? "border-primary bg-primary/5 shadow-md shadow-primary/10"
+                    : "border-border/60 hover:border-primary/30 hover:shadow-md bg-card"
+                }`}
+              >
+                <span className="text-3xl group-hover:scale-110 transition-transform duration-200 inline-block">{area.icon}</span>
+                <p className="mt-2.5 text-sm font-semibold text-foreground">{localizedLabel(area, lang)}</p>
+                <p className="mt-0.5 text-[11px] text-muted-foreground">
+                  {area.symptoms.length} {lang === "el" ? "συμπτώματα" : "symptoms"}
+                </p>
+              </button>
+            )
+          })}
         </div>
       </div>
     )
   }
 
-  // ── Step 2: Symptoms ──
   function renderSymptomsStep() {
     if (!state.selectedArea) return null
-
+    const selectedCount = state.selectedSymptoms.length
     return (
       <div>
-        <h2 className="text-lg font-semibold text-foreground mb-1">
-          {t.wizard.symptomTitle}
+        <h2 className="text-base font-bold text-foreground mb-1 flex items-center gap-2">
+          <span className="text-xl">🔍</span> {t.wizard.symptomTitle}
         </h2>
-        <p className="text-sm text-muted-foreground mb-4">
-          {localizedLabel(state.selectedArea, lang)}
-        </p>
-        <div className="space-y-2">
-          {state.selectedArea.symptoms.map((symptom) => (
-            <button
-              key={symptom.id}
-              type="button"
-              onClick={() => toggleSymptom(symptom.id)}
-              className={`w-full rounded-xl border-2 p-4 cursor-pointer text-left transition-all duration-150 ${
-                state.selectedSymptoms.includes(symptom.id)
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary/40 bg-card"
-              }`}
-            >
-              <p className="text-sm font-medium text-foreground">
-                {localizedLabel(symptom, lang)}
-              </p>
-            </button>
-          ))}
+        <p className="text-sm text-muted-foreground mb-4">{localizedLabel(state.selectedArea, lang)}</p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+          {state.selectedArea.symptoms.map((symptom) => {
+            const sel = state.selectedSymptoms.includes(symptom.id)
+            return (
+              <button
+                key={symptom.id}
+                type="button"
+                onClick={() => toggleSymptom(symptom.id)}
+                className={`${CARD_BASE} group ${
+                  sel
+                    ? "border-primary bg-primary/5 shadow-sm shadow-primary/10"
+                    : "border-border/60 hover:border-primary/30 bg-card"
+                }`}
+              >
+                <div className="flex items-center gap-2.5">
+                  <span className={`w-5 h-5 rounded-md border-2 flex items-center justify-center flex-shrink-0 transition-all ${sel ? "border-primary bg-primary text-white" : "border-border group-hover:border-primary/40"}`}>
+                    {sel && <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>}
+                  </span>
+                  <p className="text-sm font-medium text-foreground">{localizedLabel(symptom, lang)}</p>
+                </div>
+              </button>
+            )
+          })}
         </div>
         {error && (
-          <p role="alert" className="mt-3 text-sm text-destructive">
-            {error}
+          <p role="alert" className="mt-3 text-sm text-destructive font-medium">{error}</p>
+        )}
+        {selectedCount > 0 && (
+          <p className="mt-2 text-[11px] text-muted-foreground text-center">
+            {selectedCount} {lang === "el" ? "επιλεγμένα" : "selected"}
           </p>
         )}
       </div>
     )
   }
 
-  // ── Step 3: Severity ──
   function renderSeverityStep() {
     return (
       <div>
-        <h2 className="text-lg font-semibold text-foreground mb-4">
-          {t.wizard.severityTitle}
+        <h2 className="text-base font-bold text-foreground mb-4 flex items-center gap-2">
+          <span className="text-xl">📊</span> {t.wizard.severityTitle}
         </h2>
         <div className="space-y-3">
-          {SEVERITY_OPTIONS.map((option) => (
-            <button
-              key={option.id}
-              type="button"
-              onClick={() => setState((prev) => ({ ...prev, severity: option.id }))}
-              className={`w-full rounded-xl border-2 p-4 cursor-pointer text-left transition-all duration-150 ${
-                state.severity === option.id
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary/40 bg-card"
-              }`}
-            >
-              <p className="text-sm font-semibold text-foreground">
-                {localizedLabel(option, lang)}
-              </p>
-              <p className="mt-1 text-[13px] text-muted-foreground">
-                {localizedDesc(option, lang)}
-              </p>
-            </button>
-          ))}
+          {SEVERITY_OPTIONS.map((option) => {
+            const selected = state.severity === option.id
+            const gradient = SEVERITY_GRADIENTS[option.id] ?? ""
+            return (
+              <button
+                key={option.id}
+                type="button"
+                onClick={() => setState((prev) => ({ ...prev, severity: option.id }))}
+                className={`${CARD_BASE} ${gradient} group ${
+                  selected
+                    ? "border-primary bg-primary/5 shadow-md shadow-primary/10"
+                    : "border-border/60 bg-card"
+                }`}
+              >
+                <div className="flex items-center gap-3">
+                  <span className={`w-5 h-5 rounded-full border-2 flex items-center justify-center flex-shrink-0 transition-all ${selected ? "border-primary bg-primary" : "border-border group-hover:border-primary/40"}`}>
+                    {selected && <span className="w-2 h-2 rounded-full bg-white" />}
+                  </span>
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">{localizedLabel(option, lang)}</p>
+                    <p className="mt-0.5 text-[12px] text-muted-foreground">{localizedDesc(option, lang)}</p>
+                  </div>
+                </div>
+              </button>
+            )
+          })}
         </div>
       </div>
     )
   }
 
-  // ── Step 4: Duration ──
   function renderDurationStep() {
     return (
       <div>
-        <h2 className="text-lg font-semibold text-foreground mb-4">
-          {t.wizard.durationTitle}
+        <h2 className="text-base font-bold text-foreground mb-4 flex items-center gap-2">
+          <span className="text-xl">⏱️</span> {t.wizard.durationTitle}
         </h2>
-        <div className="grid grid-cols-2 gap-3">
-          {DURATION_OPTIONS.map((option) => (
-            <button
-              key={option.id}
-              type="button"
-              onClick={() => setState((prev) => ({ ...prev, duration: option.id }))}
-              className={`rounded-xl border-2 p-4 cursor-pointer text-left transition-all duration-150 ${
-                state.duration === option.id
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary/40 bg-card"
-              }`}
-            >
-              <p className="text-sm font-medium text-foreground">
-                {localizedLabel(option, lang)}
-              </p>
-            </button>
-          ))}
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          {DURATION_OPTIONS.map((option) => {
+            const selected = state.duration === option.id
+            return (
+              <button
+                key={option.id}
+                type="button"
+                onClick={() => setState((prev) => ({ ...prev, duration: option.id }))}
+                className={`${CARD_BASE} text-center group ${
+                  selected
+                    ? "border-primary bg-primary/5 shadow-md shadow-primary/10"
+                    : "border-border/60 hover:border-primary/30 hover:shadow-md bg-card"
+                }`}
+              >
+                <div className="flex items-center justify-center gap-2.5">
+                  <span className={`w-5 h-5 rounded-full border-2 flex items-center justify-center flex-shrink-0 transition-all ${selected ? "border-primary bg-primary" : "border-border group-hover:border-primary/40"}`}>
+                    {selected && <span className="w-2 h-2 rounded-full bg-white" />}
+                  </span>
+                  <p className="text-sm font-semibold text-foreground">{localizedLabel(option, lang)}</p>
+                </div>
+              </button>
+            )
+          })}
         </div>
       </div>
     )
   }
 
-  // ── Step 5: Review ──
   function renderReviewStep() {
     if (!state.selectedArea) return null
-
     const selectedSymptomItems = state.selectedSymptoms
       .map((id) => state.selectedArea!.symptoms.find((s) => s.id === id))
       .filter(Boolean)
-
     const severityOption = SEVERITY_OPTIONS.find((s) => s.id === state.severity)
     const durationOption = DURATION_OPTIONS.find((d) => d.id === state.duration)
 
     return (
       <div>
-        <h2 className="text-lg font-semibold text-foreground mb-4">
-          {t.wizard.reviewTitle}
+        <h2 className="text-base font-bold text-foreground mb-4 flex items-center gap-2">
+          <span className="text-xl">✅</span> {t.wizard.reviewTitle}
         </h2>
 
-        {/* Summary card */}
-        <div className="rounded-xl border border-border bg-card p-4 mb-4 space-y-3">
+        <div className="rounded-2xl border border-border bg-card p-5 space-y-4">
           <div>
-            <p className="text-[10px] font-bold tracking-[0.2em] text-muted-foreground mb-1">
-              {toCaps(state.selectedArea.label_en, lang)}
-            </p>
-            <div className="flex flex-wrap gap-2">
+            <p className="text-[10px] font-bold tracking-[0.2em] text-muted-foreground uppercase mb-2">{toCaps(lang === "el" ? "Περιοχή & Συμπτώματα" : "Area & Symptoms", lang)}</p>
+            <p className="text-sm font-semibold text-foreground mb-2">{localizedLabel(state.selectedArea, lang)}</p>
+            <div className="flex flex-wrap gap-1.5">
               {selectedSymptomItems.map((symptom) => (
-                <span
-                  key={symptom!.id}
-                  className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary"
-                >
+                <span key={symptom!.id} className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
                   {localizedLabel(symptom!, lang)}
                 </span>
               ))}
             </div>
           </div>
 
-          <div className="border-t border-border pt-3 grid grid-cols-2 gap-3">
+          <div className="border-t border-border pt-4 grid grid-cols-2 gap-4">
             <div>
-              <p className="text-[10px] font-bold tracking-[0.2em] text-muted-foreground">
-                {toCaps(t.wizard.severityTitle, lang)}
-              </p>
-              <p className="mt-0.5 text-sm font-medium text-foreground">
-                {severityOption ? localizedLabel(severityOption, lang) : "—"}
-              </p>
+              <p className="text-[10px] font-bold tracking-[0.2em] text-muted-foreground uppercase mb-1">📊 {toCaps(t.wizard.severityTitle, lang)}</p>
+              <p className="text-sm font-semibold text-foreground">{severityOption ? localizedLabel(severityOption, lang) : "—"}</p>
             </div>
             <div>
-              <p className="text-[10px] font-bold tracking-[0.2em] text-muted-foreground">
-                {toCaps(t.wizard.durationTitle, lang)}
-              </p>
-              <p className="mt-0.5 text-sm font-medium text-foreground">
-                {durationOption ? localizedLabel(durationOption, lang) : "—"}
-              </p>
+              <p className="text-[10px] font-bold tracking-[0.2em] text-muted-foreground uppercase mb-1">⏱️ {toCaps(t.wizard.durationTitle, lang)}</p>
+              <p className="text-sm font-semibold text-foreground">{durationOption ? localizedLabel(durationOption, lang) : "—"}</p>
             </div>
           </div>
         </div>
 
-        {/* Additional notes */}
-        <div>
-          <label
-            htmlFor="wizard-notes"
-            className="block text-[10px] font-bold tracking-[0.2em] text-muted-foreground mb-2"
-          >
+        <div className="mt-4">
+          <label htmlFor="wizard-notes" className="block text-[10px] font-bold tracking-[0.2em] text-muted-foreground mb-2">
             {toCaps(t.wizard.additionalNotes, lang)}
           </label>
           <textarea
             id="wizard-notes"
             rows={3}
             disabled={isLoading}
-            className="block w-full rounded-md border border-border px-3 py-2 text-sm text-foreground placeholder-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 bg-card"
-            placeholder={
-              lang === "el"
-                ? "Οτιδήποτε άλλο θέλετε να προσθέσετε..."
-                : "Anything else you'd like to add..."
-            }
+            className="block w-full rounded-xl border border-border px-4 py-3 text-sm text-foreground placeholder-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 bg-card resize-none"
+            placeholder={lang === "el" ? "Οτιδήποτε άλλο θέλετε να προσθέσετε..." : "Anything else you'd like to add..."}
             value={state.additionalNotes}
             onChange={(e) => setState((prev) => ({ ...prev, additionalNotes: e.target.value }))}
           />
         </div>
 
         {error && (
-          <div
-            role="alert"
-            className="mt-4 rounded-md bg-destructive/10 p-4 text-sm text-destructive border border-destructive/20"
-          >
-            {error}
-          </div>
+          <div role="alert" className="mt-4 rounded-lg bg-destructive/10 p-3 text-sm text-destructive border border-destructive/20">{error}</div>
         )}
       </div>
     )
   }
 
-  // ── Render current step ──
   function renderCurrentStep() {
     switch (state.step) {
-      case "body-area":
-        return renderBodyAreaStep()
-      case "symptoms":
-        return renderSymptomsStep()
-      case "severity":
-        return renderSeverityStep()
-      case "duration":
-        return renderDurationStep()
-      case "review":
-        return renderReviewStep()
+      case "body-area": return renderBodyAreaStep()
+      case "symptoms": return renderSymptomsStep()
+      case "severity": return renderSeverityStep()
+      case "duration": return renderDurationStep()
+      case "review": return renderReviewStep()
     }
   }
 
   return (
     <div>
       {renderStepIndicator()}
-      <div className="space-y-6">{renderCurrentStep()}</div>
+      <div className="min-h-[200px]">{renderCurrentStep()}</div>
 
-      {/* Navigation buttons */}
       <div className="flex items-center gap-3 mt-6">
         {currentStepIndex > 0 && (
           <button
             type="button"
             onClick={goBack}
             disabled={isLoading}
-            className="rounded-md border border-border bg-card px-4 py-3 text-sm font-medium text-foreground hover:bg-border/50 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+            className="rounded-xl border border-border bg-card px-5 py-3 text-sm font-semibold text-foreground hover:bg-muted transition-colors disabled:cursor-not-allowed disabled:opacity-50"
           >
             {t.wizard.back}
           </button>
@@ -461,10 +431,18 @@ export default function SymptomWizard({ patientId, onResult, onStartLoading, lat
           type="button"
           onClick={handleNext}
           disabled={!canProceed || isLoading}
-          className="flex-1 rounded-md bg-primary px-4 py-3 text-sm font-medium text-white hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-colors"
+          className="flex-1 rounded-xl bg-primary px-5 py-3 text-sm font-semibold text-white hover:bg-primary-hover transition-all disabled:cursor-not-allowed disabled:opacity-50 shadow-md shadow-primary/20 hover:shadow-lg hover:shadow-primary/25"
         >
           {isLoading
-            ? t.form.loading
+            ? (
+              <span className="flex items-center justify-center gap-2">
+                <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                {t.form.loading}
+              </span>
+            )
             : state.step === "review"
               ? t.wizard.submit
               : t.wizard.next}

--- a/frontend/app/components/ThemeToggle.tsx
+++ b/frontend/app/components/ThemeToggle.tsx
@@ -3,32 +3,27 @@
 import { useTheme } from "@/app/lib/theme-context"
 
 export default function ThemeToggle() {
-  try {
-    const { theme, resolvedTheme, toggleTheme } = useTheme()
+  const { theme, toggleTheme } = useTheme()
 
-    const nextLabel =
-      theme === "light" ? "dark" : theme === "dark" ? "system" : "light"
+  const nextLabel = theme === "light" ? "dark" : "light"
 
-    return (
-      <button
-        type="button"
-        onClick={toggleTheme}
-        aria-label={`Switch to ${nextLabel} mode`}
-        title={`Switch to ${nextLabel} mode`}
-        className="theme-toggle-btn w-11 h-11 rounded-full flex items-center justify-center border border-border/50 bg-card/60 backdrop-blur-md shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
-      >
-        {resolvedTheme === "light" ? (
-          <svg className="w-[18px] h-[18px] text-foreground/70" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden="true">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
-          </svg>
-        ) : (
-          <svg className="w-[18px] h-[18px] text-foreground/80" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden="true">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-          </svg>
-        )}
-      </button>
-    )
-  } catch {
-    return null
-  }
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={`Switch to ${nextLabel} mode`}
+      title={`Switch to ${nextLabel} mode`}
+      className="theme-toggle-btn w-11 h-11 rounded-full flex items-center justify-center border border-border/50 bg-card/60 backdrop-blur-md shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+    >
+      {theme === "light" ? (
+        <svg className="w-[18px] h-[18px] text-foreground/70" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+        </svg>
+      ) : (
+        <svg className="w-[18px] h-[18px] text-foreground/80" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+        </svg>
+      )}
+    </button>
+  )
 }

--- a/frontend/app/components/TriageForm.tsx
+++ b/frontend/app/components/TriageForm.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { submitTriage } from "@/app/lib/api"
 import { FollowUpResponse, TriageResponse } from "@/app/lib/types"
 import { useLang } from "@/app/lib/lang-context"
+import { QUICK_SYMPTOMS } from "@/app/lib/wizard-data"
 
 interface TriageFormProps {
   onResult: (result: TriageResponse) => void
@@ -11,6 +12,10 @@ interface TriageFormProps {
   patientId: string
   latitude: number | null
   longitude: number | null
+  geoDenied: boolean
+  geoLoading: boolean
+  geoDismissed: boolean
+  onRequestLocation: () => void
 }
 
 interface FollowUpState {
@@ -19,13 +24,43 @@ interface FollowUpState {
   conversationContext: string
 }
 
-export default function TriageForm({ onResult, onStartLoading, patientId, latitude, longitude }: TriageFormProps) {
+const PROMPTS = [
+  { en: "How are you feeling today? Describe your symptoms.", el: "Πώς αισθάνεστε σήμερα; Περιγράψτε τα συμπτώματά σας." },
+  { en: "What brought you here? Tell us what's bothering you.", el: "Τι σας έφερε εδώ; Πείτε μας τι σας απασχολεί." },
+  { en: "Where does it hurt? Be as specific as you can.", el: "Πού πονάτε; Περιγράψτε όσο πιο συγκεκριμένα μπορείτε." },
+  { en: "When did your symptoms start? Describe how you feel.", el: "Πότε ξεκίνησαν τα συμπτώματα; Περιγράψτε πώς αισθάνεστε." },
+  { en: "Tell us your symptoms — we're here to help.", el: "Πείτε μας τα συμπτώματά σας — είμαστε εδώ για να βοηθήσουμε." },
+  { en: "Describe what you're experiencing right now.", el: "Περιγράψτε τι βιώνετε αυτή τη στιγμή." },
+  { en: "What's on your mind? Share your health concerns.", el: "Τι σας απασχολεί; Μοιραστείτε τις ανησυχίες σας για την υγεία σας." },
+]
+
+export default function TriageForm({
+  onResult,
+  onStartLoading,
+  patientId,
+  latitude,
+  longitude,
+  geoDenied,
+  geoLoading,
+  geoDismissed,
+  onRequestLocation,
+}: TriageFormProps) {
   const [symptoms, setSymptoms] = useState("")
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [followUp, setFollowUp] = useState<FollowUpState | null>(null)
   const [followUpAnswer, setFollowUpAnswer] = useState("")
+  const [userDismissed, setUserDismissed] = useState(false)
+  const [chipsVisible, setChipsVisible] = useState(true)
+  const [promptIdx, setPromptIdx] = useState(0)
   const { t, lang } = useLang()
+
+  // Random daily prompt — safe one-time init after mount
+  useEffect(() => {
+    setPromptIdx(Math.floor(Math.random() * PROMPTS.length))
+  }, [])
+
+  const prompt = PROMPTS[promptIdx]
 
   const handleReset = () => {
     setFollowUp(null)
@@ -50,8 +85,7 @@ export default function TriageForm({ onResult, onStartLoading, patientId, latitu
         onResult(result as TriageResponse)
         setSymptoms("")
       }
-    } catch (err) {
-      console.error("[TriageForm] submit error:", err)
+    } catch {
       setError(t.form.error)
     } finally {
       setIsLoading(false)
@@ -81,36 +115,48 @@ export default function TriageForm({ onResult, onStartLoading, patientId, latitu
         setFollowUpAnswer("")
         setSymptoms("")
       }
-    } catch (err) {
-      console.error("[TriageForm] follow-up error:", err)
+    } catch {
       setError(t.form.error)
     } finally {
       setIsLoading(false)
     }
   }
 
+  const addSymptomChip = (fill: string) => {
+    setChipsVisible(false)
+    setSymptoms((prev) => {
+      const trimmed = prev.trim()
+      if (!trimmed) return fill
+      if (trimmed.endsWith(".") || trimmed.endsWith(",")) return `${prev} ${fill}`
+      return `${prev}, ${fill}`
+    })
+  }
+
+  const showLocationHint = !followUp && symptoms.trim().length > 0 && latitude === null && !userDismissed && !geoDismissed
+
   if (followUp) {
     return (
-      <form onSubmit={handleFollowUpSubmit} className="space-y-6">
-        <div className="rounded-md border border-primary/30 bg-primary/5 p-4 text-sm text-foreground">
-          <p className="mb-1 font-medium text-primary">{t.followUp.questionLabel}</p>
-          <p>{followUp.question}</p>
+      <form onSubmit={handleFollowUpSubmit} className="space-y-5">
+        <div className="flex items-start gap-3 rounded-xl border border-primary/30 bg-primary/5 p-4">
+          <span className="text-lg mt-0.5">🤖</span>
+          <div className="text-sm text-foreground">
+            <p className="mb-1 font-semibold text-primary">{t.followUp.questionLabel}</p>
+            <p>{followUp.question}</p>
+          </div>
         </div>
 
-        <div>
-          <textarea
-            rows={3}
-            required
-            disabled={isLoading}
-            className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground placeholder-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 sm:text-sm bg-card"
-            placeholder={t.followUp.answerPlaceholder}
-            value={followUpAnswer}
-            onChange={(e) => setFollowUpAnswer(e.target.value)}
-          />
-        </div>
+        <textarea
+          rows={3}
+          required
+          disabled={isLoading}
+          className="block w-full rounded-xl border border-border px-4 py-3 text-sm text-foreground placeholder-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 bg-card resize-none"
+          placeholder={t.followUp.answerPlaceholder}
+          value={followUpAnswer}
+          onChange={(e) => setFollowUpAnswer(e.target.value)}
+        />
 
         {error && (
-          <div role="alert" className="rounded-md bg-destructive/10 p-4 text-sm text-destructive border border-destructive/20">
+          <div role="alert" className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive border border-destructive/20">
             {error}
           </div>
         )}
@@ -120,14 +166,14 @@ export default function TriageForm({ onResult, onStartLoading, patientId, latitu
             type="button"
             disabled={isLoading}
             onClick={handleReset}
-            className="flex-1 rounded-md border border-border px-4 py-3 text-sm font-medium text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex-1 rounded-xl border border-border px-4 py-3 text-sm font-semibold text-foreground hover:bg-muted transition-colors disabled:cursor-not-allowed disabled:opacity-50"
           >
             {t.followUp.back}
           </button>
           <button
             type="submit"
             disabled={isLoading}
-            className="flex-1 rounded-md bg-primary px-4 py-3 text-sm font-medium text-white hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex-1 rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white hover:bg-primary-hover transition-all disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isLoading ? t.form.loading : t.followUp.submit}
           </button>
@@ -137,36 +183,109 @@ export default function TriageForm({ onResult, onStartLoading, patientId, latitu
   }
 
   return (
-    <form onSubmit={handleInitialSubmit} className="space-y-6">
-      <div>
-        <label htmlFor="symptoms" className="block text-sm font-medium text-foreground">
-          {t.form.label}
-        </label>
+    <form onSubmit={handleInitialSubmit} className="space-y-5">
+      {/* Daily prompt */}
+      <p className="text-center text-sm font-medium italic text-primary/80 tracking-wide">
+        {lang === "el" ? prompt.el : prompt.en}
+      </p>
+
+      {/* Quick symptom chips */}
+      <div
+        className={`grid transition-[grid-template-rows] duration-400 ease-out ${
+          chipsVisible ? "[grid-template-rows:1fr] opacity-100" : "[grid-template-rows:0fr] opacity-0"
+        }`}
+      >
+        <div className="overflow-hidden">
+          <div className="flex flex-wrap justify-center gap-1.5">
+        {QUICK_SYMPTOMS.map((chip) => (
+          <button
+            key={chip.id}
+            type="button"
+            onClick={() => addSymptomChip(lang === "el" ? chip.label_el : chip.fill)}
+            className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2.5 py-1 text-[11px] font-medium text-muted-foreground hover:text-foreground hover:border-primary/30 hover:bg-primary/5 transition-all"
+          >
+            <span className="text-xs">{chip.icon}</span>
+            <span>{lang === "el" ? chip.label_el : chip.label_en}</span>
+          </button>
+        ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Textarea */}
+      <div className="relative">
         <textarea
           id="symptoms"
           name="symptoms"
           rows={4}
           required
           disabled={isLoading}
-          className="mt-1 block w-full rounded-md border border-border px-3 py-2 text-foreground placeholder-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 sm:text-sm bg-card"
+          className="block w-full rounded-xl border border-border px-4 py-3 text-sm text-foreground placeholder-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 bg-card resize-none"
           placeholder={t.form.placeholder}
           value={symptoms}
-          onChange={(e) => setSymptoms(e.target.value)}
+          onChange={(e) => {
+            setSymptoms(e.target.value)
+            setChipsVisible(e.target.value.trim().length === 0)
+          }}
         />
+        <div className="absolute bottom-2 right-3 text-[10px] text-muted-foreground/50 tabular-nums pointer-events-none select-none">
+          {symptoms.length > 0 && `${symptoms.length}`}
+        </div>
       </div>
 
       {error && (
-        <div role="alert" className="rounded-md bg-destructive/10 p-4 text-sm text-destructive border border-destructive/20">
+        <div role="alert" className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive border border-destructive/20">
           {error}
         </div>
       )}
 
+      {/* Location hint */}
+      {showLocationHint && !geoDenied && (
+        <div className="flex items-center justify-between gap-2 rounded-lg border border-primary/20 bg-primary/5 px-3 py-2">
+          <span className="text-[11px] text-muted-foreground flex-1 min-w-0">{t.doctor.locationBanner}</span>
+          <button type="button" onClick={onRequestLocation} disabled={geoLoading} className="shrink-0 rounded-full bg-primary px-2.5 py-1 text-[10px] font-semibold text-white hover:bg-primary-hover transition-colors">
+            {geoLoading ? "..." : t.doctor.enableLocation}
+          </button>
+          <button type="button" onClick={() => setUserDismissed(true)} className="shrink-0 text-[10px] text-muted-foreground hover:text-foreground transition-colors">
+            {t.doctor.skipLocation}
+          </button>
+        </div>
+      )}
+
+      {showLocationHint && geoDenied && (
+        <div className="flex items-center justify-between gap-2 rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2">
+          <span className="text-[11px] text-muted-foreground flex-1 min-w-0">{t.doctor.locationDenied}</span>
+          <button type="button" onClick={onRequestLocation} className="shrink-0 text-[11px] text-primary hover:text-primary-hover transition-colors font-semibold">Try again</button>
+        </div>
+      )}
+
+      {/* Submit */}
       <button
         type="submit"
         disabled={isLoading}
-        className="w-full rounded-md bg-primary px-4 py-3 text-sm font-medium text-white hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+        className="group relative w-full rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white hover:bg-primary-hover transition-all disabled:cursor-not-allowed disabled:opacity-50 overflow-hidden"
       >
-        {isLoading ? t.form.loading : t.form.submit}
+        <span className="relative z-10 flex items-center justify-center gap-2">
+          {isLoading ? (
+            <>
+              <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+              {t.form.loading}
+            </>
+          ) : (
+            <>
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" />
+              </svg>
+              {t.form.submit}
+            </>
+          )}
+        </span>
+        {!isLoading && (
+          <span className="absolute inset-0 bg-white/10 scale-x-0 group-hover:scale-x-100 transition-transform duration-500 origin-left rounded-xl" />
+        )}
       </button>
     </form>
   )

--- a/frontend/app/doctors/page.tsx
+++ b/frontend/app/doctors/page.tsx
@@ -1,0 +1,319 @@
+"use client"
+
+import { useEffect, useState, useMemo } from "react"
+import Link from "next/link"
+import { useTriageStream } from "@/app/lib/useTriageStream"
+import { resolveApiBase, buildApiUrl } from "@/app/lib/backendResolver"
+import { QueueEntry } from "@/app/lib/types"
+import { useLang } from "@/app/lib/lang-context"
+import { toCaps } from "@/app/lib/casing"
+
+interface Doctor {
+  name: string
+  specialty: string
+  availability: boolean
+  fallback_note: string | null
+  city: string | null
+  lat: number | null
+  lon: number | null
+}
+
+const MTS_COLORS: Record<number, { bg: string; text: string; label: string }> = {
+  1: { bg: "bg-red-500",    text: "text-red-500",    label: "Immediate"   },
+  2: { bg: "bg-orange-500", text: "text-orange-500", label: "Very Urgent" },
+  3: { bg: "bg-yellow-500", text: "text-yellow-500", label: "Urgent"      },
+  4: { bg: "bg-green-500",  text: "text-green-500",  label: "Less Urgent" },
+  5: { bg: "bg-blue-500",   text: "text-blue-500",   label: "Non-Urgent"  },
+}
+
+const QUEUE_MTS_LABELS: Record<number, string> = {
+  1: "Immediate", 2: "Very Urgent", 3: "Urgent", 4: "Less Urgent", 5: "Non-Urgent",
+}
+
+function Card({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div className={`triage-card rounded-2xl border border-primary/20 bg-card p-5 ${className ?? ""}`}>
+      {children}
+    </div>
+  )
+}
+
+function Shimmer({ className }: { className?: string }) {
+  return <div className={`skeleton rounded-xl animate-pulse ${className ?? "h-16"}`} />
+}
+
+export default function DoctorsPage() {
+  const { lang } = useLang()
+  const queueEntries = useTriageStream()
+
+  const [doctors, setDoctors] = useState<Doctor[]>([])
+  const [doctorsLoading, setDoctorsLoading] = useState(true)
+
+  const [loggedInDoctor, setLoggedInDoctor] = useState<Doctor | null>(null)
+  const [selectedDoctor, setSelectedDoctor] = useState("")
+  const [password, setPassword] = useState("")
+  const [loginError, setLoginError] = useState("")
+  const [loginLoading, setLoginLoading] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    resolveApiBase()
+      .then((base) => fetch(buildApiUrl(base, "/api/v1/doctors")))
+      .then((res) => {
+        if (!res.ok) throw new Error(`${res.status}`)
+        return res.json() as Promise<Doctor[]>
+      })
+      .then((data) => { if (!cancelled) { setDoctors(data); setDoctorsLoading(false) } })
+      .catch(() => { if (!cancelled) setDoctorsLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  const handleLogin = (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoginError("")
+
+    if (!selectedDoctor) {
+      setLoginError(lang === "el" ? "Επιλέξτε γιατρό" : "Please select a doctor")
+      return
+    }
+    if (password !== "password") {
+      setLoginError(lang === "el" ? "Λάθος κωδικός" : "Wrong password")
+      return
+    }
+
+    setLoginLoading(true)
+    setTimeout(() => {
+      const doc = doctors.find((d) => d.name === selectedDoctor)
+      if (doc) {
+        setLoggedInDoctor(doc)
+      }
+      setLoginLoading(false)
+    }, 400)
+  }
+
+  const assignedPatients = useMemo(() => {
+    if (!loggedInDoctor) return []
+    return queueEntries.filter((e) =>
+      e.specialty.toLowerCase() === loggedInDoctor.specialty.toLowerCase()
+    )
+  }, [queueEntries, loggedInDoctor])
+
+  const groupedByLevel = useMemo(() => {
+    const groups: Record<number, QueueEntry[]> = { 1: [], 2: [], 3: [], 4: [], 5: [] }
+    assignedPatients.forEach((p) => {
+      if (groups[p.mts_level]) groups[p.mts_level].push(p)
+    })
+    return groups
+  }, [assignedPatients])
+
+  const handleLogout = () => {
+    setLoggedInDoctor(null)
+    setSelectedDoctor("")
+    setPassword("")
+    setLoginError("")
+  }
+
+  return (
+    <div className="hero-section relative min-h-screen flex flex-col">
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="hero-orb-1 absolute w-[600px] h-[600px] rounded-full -top-32 -left-16" />
+        <div className="hero-orb-2 absolute w-[480px] h-[480px] rounded-full -bottom-24 -right-16" />
+      </div>
+
+      <div className="relative flex-1 max-w-4xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8 space-y-5">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Link
+              href="/"
+              className="w-10 h-10 rounded-full flex items-center justify-center border border-border/50 bg-card/60 backdrop-blur-md shadow-lg transition-colors hover:bg-card/80"
+              aria-label="Back to home"
+            >
+              <svg className="w-[16px] h-[16px] text-foreground/70" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+              </svg>
+            </Link>
+            <h1 className="text-xl font-bold text-foreground">
+              MED<span className="logo-omega text-primary">Ω</span>
+            </h1>
+          </div>
+          <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase hidden sm:block">
+            {toCaps("Doctors Dashboard", lang)}
+          </p>
+        </div>
+
+        {!loggedInDoctor ? (
+          <div className="max-w-md mx-auto w-full">
+            <Card className="p-6">
+              <h2 className="text-base font-bold text-foreground mb-5 text-center">
+                {lang === "el" ? "Σύνδεση Ιατρού" : "Doctor Login"}
+              </h2>
+
+              {doctorsLoading ? (
+                <div className="space-y-4">
+                  <Shimmer className="h-10" />
+                  <Shimmer className="h-10" />
+                  <Shimmer className="h-10" />
+                </div>
+              ) : (
+                <form onSubmit={handleLogin} className="space-y-3.5">
+                  <div>
+                    <label htmlFor="doctor-select" className="block text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase mb-1.5">
+                      {lang === "el" ? "Επιλέξτε Ιατρό" : "Select Doctor"}
+                    </label>
+                    <select
+                      id="doctor-select"
+                      value={selectedDoctor}
+                      onChange={(e) => setSelectedDoctor(e.target.value)}
+                      className="block w-full rounded-lg border border-border bg-card px-3.5 py-2.5 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                    >
+                      <option value="">{lang === "el" ? "— Επιλέξτε —" : "— Select —"}</option>
+                      {doctors.map((doc) => (
+                        <option key={doc.name} value={doc.name}>
+                          {doc.name} — {doc.specialty}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div>
+                    <label htmlFor="doctor-password" className="block text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase mb-1.5">
+                      {lang === "el" ? "Κωδικός" : "Password"}
+                    </label>
+                    <input
+                      id="doctor-password"
+                      type="password"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      className="block w-full rounded-xl border border-border bg-card px-4 py-3 text-sm text-foreground placeholder-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                      placeholder="········"
+                    />
+                  </div>
+
+                  {loginError && (
+                    <p className="text-sm text-destructive font-medium text-center">{loginError}</p>
+                  )}
+
+                  <button
+                    type="submit"
+                    disabled={loginLoading}
+                    className="w-full rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-white hover:bg-primary-hover transition-all shadow-md shadow-primary/20"
+                  >
+                    {loginLoading ? (
+                      <span className="flex items-center justify-center gap-2">
+                        <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                        </svg>
+                        {lang === "el" ? "Σύνδεση..." : "Logging in..."}
+                      </span>
+                    ) : (
+                      lang === "el" ? "Σύνδεση" : "Login"
+                    )}
+                  </button>
+                </form>
+              )}
+            </Card>
+          </div>
+        ) : (
+          <>
+            {/* Logged-in header */}
+            <Card>
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-bold text-foreground">{loggedInDoctor.name}</p>
+                  <p className="text-[11px] text-muted-foreground">
+                    {loggedInDoctor.specialty}
+                    {loggedInDoctor.city && ` · ${loggedInDoctor.city}`}
+                  </p>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className={`inline-flex items-center gap-1.5 text-[10px] font-semibold ${loggedInDoctor.availability ? "text-success" : "text-destructive"}`}>
+                    <span className={`w-1.5 h-1.5 rounded-full ${loggedInDoctor.availability ? "bg-success" : "bg-destructive"}`} />
+                    {loggedInDoctor.availability ? (lang === "el" ? "Διαθέσιμος" : "Available") : (lang === "el" ? "Μη Διαθέσιμος" : "Unavailable")}
+                  </span>
+                  <button
+                    onClick={handleLogout}
+                    className="text-[10px] text-muted-foreground hover:text-destructive transition-colors font-semibold"
+                  >
+                    {lang === "el" ? "Αποσύνδεση" : "Logout"}
+                  </button>
+                </div>
+              </div>
+            </Card>
+
+            {/* Stats row */}
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              {[1, 2, 3, 4, 5].map((level) => {
+                const palette = MTS_COLORS[level] ?? MTS_COLORS[5]
+                const count = groupedByLevel[level]?.length ?? 0
+                return (
+                  <Card key={level}>
+                    <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase mb-1">
+                      {lang === "el" ? `Επίπεδο ${level}` : `Level ${level}`}
+                    </p>
+                    <p className={`text-2xl font-black ${palette.text}`}>{count}</p>
+                    <p className="text-[10px] text-muted-foreground mt-0.5">{palette.label}</p>
+                  </Card>
+                )
+              })}
+            </div>
+
+            {/* Patient lists by urgency */}
+            {[1, 2, 3, 4, 5].map((level) => {
+              const patients = groupedByLevel[level] ?? []
+              if (patients.length === 0) return null
+              const palette = MTS_COLORS[level] ?? MTS_COLORS[5]
+              return (
+                <Card key={level}>
+                  <div className="flex items-center gap-2 mb-4">
+                    <span className={`inline-block w-2.5 h-2.5 rounded-full ${palette.bg}`} />
+                    <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase">
+                      {QUEUE_MTS_LABELS[level]} ({patients.length})
+                    </p>
+                  </div>
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full text-sm">
+                      <thead>
+                        <tr className="border-b border-border">
+                          <th className="text-left py-2 px-2 text-[9px] font-bold tracking-[0.15em] text-muted-foreground uppercase">Time</th>
+                          <th className="text-left py-2 px-2 text-[9px] font-bold tracking-[0.15em] text-muted-foreground uppercase">Patient ID</th>
+                          <th className="text-left py-2 px-2 text-[9px] font-bold tracking-[0.15em] text-muted-foreground uppercase">Specialty</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {patients.map((entry) => {
+                          const date = new Date(entry.timestamp)
+                          const time = Number.isNaN(date.getTime())
+                            ? "—"
+                            : date.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", second: "2-digit" })
+                          return (
+                            <tr key={`${entry.patient_id}-${entry.timestamp}`} className={`border-b border-border/40 ${level <= 2 ? "bg-destructive/5" : ""}`}>
+                              <td className="py-1.5 px-2 text-[11px] text-muted-foreground font-mono whitespace-nowrap">{time}</td>
+                              <td className="py-1.5 px-2 text-[11px] text-foreground font-mono">{entry.patient_id.slice(0, 12)}...</td>
+                              <td className="py-1.5 px-2 text-[11px] text-foreground">{entry.specialty}</td>
+                            </tr>
+                          )
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </Card>
+              )
+            })}
+
+            {assignedPatients.length === 0 && (
+              <Card>
+                <p className="text-sm text-muted-foreground text-center py-8">
+                  {lang === "el"
+                    ? "Δεν υπάρχουν ασθενείς στην ειδικότητά σας αυτή τη στιγμή."
+                    : "No patients in your specialty at the moment."}
+                </p>
+              </Card>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -252,6 +252,12 @@ body {
   0% { background-position: -200% 0; }
   100% { background-position: 200% 0; }
 }
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 .skeleton {
   background: linear-gradient(90deg, var(--muted) 25%, var(--border) 50%, var(--muted) 75%);
   background-size: 200% 100%;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -5,12 +5,13 @@ import { ThemeProvider } from "@/app/lib/theme-context";
 import { LangProvider } from "@/app/lib/lang-context";
 import ThemeToggle from "@/app/components/ThemeToggle";
 import LangToggle from "@/app/components/LangToggle";
-import SettingsLink from "@/app/components/SettingsLink";
-import AnalyticsLink from "@/app/components/AnalyticsLink";
+import DoctorsLink from "@/app/components/DoctorsLink";
+import HistoryToggle from "@/app/components/HistoryToggle";
+import ManagementLink from "@/app/components/ManagementLink";
 import EmergencyBar from "@/app/components/EmergencyBar";
 import ErrorBoundary from "@/app/components/ErrorBoundary";
-import InstallPrompt from "@/app/components/InstallPrompt";
 import { Toaster } from "react-hot-toast";
+import { Suspense } from "react";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -58,6 +59,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
+      data-scroll-behavior="smooth"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
@@ -71,10 +73,13 @@ export default function RootLayout({
           <LangProvider>
             {/* Floating controls — top right */}
             <div className="fixed top-4 right-4 z-50 flex items-center gap-2">
+              <DoctorsLink />
               <LangToggle />
               <ThemeToggle />
-              <AnalyticsLink />
-              <SettingsLink />
+              <Suspense fallback={<div className="w-11 h-11" />}>
+                <HistoryToggle />
+              </Suspense>
+              <ManagementLink />
             </div>
 
             <ErrorBoundary>
@@ -85,7 +90,6 @@ export default function RootLayout({
             </ErrorBoundary>
 
             <EmergencyBar />
-            <InstallPrompt />
           </LangProvider>
         </ThemeProvider>
       </body>

--- a/frontend/app/lib/theme-context.tsx
+++ b/frontend/app/lib/theme-context.tsx
@@ -2,53 +2,37 @@
 
 import { createContext, useContext, useEffect, useState } from "react"
 
-type Theme = "light" | "dark" | "system"
-type ResolvedTheme = "light" | "dark"
+type Theme = "light" | "dark"
 
 interface ThemeContextType {
   theme: Theme
-  resolvedTheme: ResolvedTheme
   setTheme: (theme: Theme) => void
   toggleTheme: () => void
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
 
-function getSystemTheme(): ResolvedTheme {
-  if (typeof window === "undefined") return "light"
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
-}
-
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>("system")
-  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("light")
+  const [theme, setThemeState] = useState<Theme>("light")
   const [mounted, setMounted] = useState(false)
 
-  // Initialize theme from localStorage or default to system
   useEffect(() => {
     try {
-      const stored = localStorage.getItem("theme") as Theme | null
-      if (stored === "light" || stored === "dark" || stored === "system") {
+      const stored = localStorage.getItem("theme")
+      if (stored === "light" || stored === "dark") {
         setThemeState(stored)
-      } else {
-        setThemeState("system")
       }
     } catch {
-      console.warn("localStorage unavailable, defaulting to system theme")
-      setThemeState("system")
+      console.warn("localStorage unavailable")
     }
     setMounted(true)
   }, [])
 
-  // Apply theme to document and persist to localStorage
   useEffect(() => {
     if (!mounted) return
 
-    const resolved = theme === "system" ? getSystemTheme() : theme
-    setResolvedTheme(resolved)
-
     try {
-      if (resolved === "dark") {
+      if (theme === "dark") {
         document.documentElement.setAttribute("data-theme", "dark")
         document.documentElement.classList.add("dark")
       } else {
@@ -61,43 +45,24 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     }
   }, [theme, mounted])
 
-  // Listen for system preference changes when theme is "system"
-  useEffect(() => {
-    if (!mounted || theme !== "system") return
-
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
-    const handleChange = () => {
-      setResolvedTheme(mediaQuery.matches ? "dark" : "light")
-      if (mediaQuery.matches) {
-        document.documentElement.setAttribute("data-theme", "dark")
-        document.documentElement.classList.add("dark")
-      } else {
-        document.documentElement.setAttribute("data-theme", "light")
-        document.documentElement.classList.remove("dark")
-      }
-    }
-    mediaQuery.addEventListener("change", handleChange)
-    return () => mediaQuery.removeEventListener("change", handleChange)
-  }, [mounted, theme])
-
   const setTheme = (newTheme: Theme) => {
     setThemeState(newTheme)
   }
 
   const toggleTheme = () => {
-    setThemeState((prev) => {
-      if (prev === "light") return "dark"
-      if (prev === "dark") return "system"
-      return "light"
-    })
+    setThemeState((prev) => (prev === "light" ? "dark" : "light"))
   }
 
   if (!mounted) {
-    return <>{children}</>
+    return (
+      <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+        {children}
+      </ThemeContext.Provider>
+    )
   }
 
   return (
-    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
       {children}
     </ThemeContext.Provider>
   )

--- a/frontend/app/lib/useGeolocation.ts
+++ b/frontend/app/lib/useGeolocation.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useState, useCallback, useEffect, useRef } from "react"
 
 export interface GeolocationState {
   latitude: number | null
@@ -8,7 +8,10 @@ export interface GeolocationState {
   error: string | null
   loading: boolean
   denied: boolean
+  ipBased: boolean
   request: () => void
+  dismiss: () => void
+  dismissed: boolean
 }
 
 const GEO_OPTIONS: PositionOptions = {
@@ -23,6 +26,32 @@ export function useGeolocation(): GeolocationState {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [denied, setDenied] = useState(false)
+  const [ipBased, setIpBased] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+  const ipRan = useRef(false)
+
+  const dismiss = useCallback(() => setDismissed(true), [])
+
+  useEffect(() => {
+    if (ipRan.current) return
+    ipRan.current = true
+
+    let cancelled = false
+    fetch("https://ipapi.co/json/", { signal: AbortSignal.timeout(5000) })
+      .then((res) => {
+        if (!res.ok || cancelled) return null
+        return res.json() as Promise<{ latitude?: number; longitude?: number; error?: boolean }>
+      })
+      .then((data) => {
+        if (cancelled || !data || data.error || !data.latitude || !data.longitude) return
+        setLatitude(data.latitude)
+        setLongitude(data.longitude)
+        setIpBased(true)
+      })
+      .catch(() => { /* IP geolocation unavailable */ })
+
+    return () => { cancelled = true }
+  }, [])
 
   const request = useCallback(() => {
     if (!("geolocation" in navigator)) {
@@ -30,12 +59,14 @@ export function useGeolocation(): GeolocationState {
       setDenied(true)
       return
     }
+    setDismissed(false)
     setLoading(true)
     setError(null)
     navigator.geolocation.getCurrentPosition(
       (position) => {
         setLatitude(position.coords.latitude)
         setLongitude(position.coords.longitude)
+        setIpBased(false)
         setLoading(false)
       },
       (err) => {
@@ -49,5 +80,5 @@ export function useGeolocation(): GeolocationState {
     )
   }, [])
 
-  return { latitude, longitude, error, loading, denied, request }
+  return { latitude, longitude, error, loading, denied, ipBased, request, dismiss, dismissed }
 }

--- a/frontend/app/lib/wizard-data.ts
+++ b/frontend/app/lib/wizard-data.ts
@@ -157,3 +157,22 @@ export const DURATION_OPTIONS: DurationOption[] = [
   { id: "weeks", label_en: "Several weeks", label_el: "Πολλές εβδομάδες" },
   { id: "longer", label_en: "Months or longer", label_el: "Μήνες ή περισσότερο" },
 ]
+
+export interface QuickSymptom {
+  id: string
+  label_en: string
+  label_el: string
+  fill: string
+  icon: string
+}
+
+export const QUICK_SYMPTOMS: QuickSymptom[] = [
+  { id: "headache", label_en: "Headache", label_el: "Πονοκέφαλος", fill: "Headache", icon: "🤕" },
+  { id: "chest_pain", label_en: "Chest pain", label_el: "Πόνος στο στήθος", fill: "Chest pain", icon: "💔" },
+  { id: "fever", label_en: "Fever", label_el: "Πυρετός", fill: "Fever", icon: "🌡️" },
+  { id: "cough", label_en: "Cough", label_el: "Βήχας", fill: "Cough", icon: "🫁" },
+  { id: "nausea", label_en: "Nausea", label_el: "Ναυτία", fill: "Nausea / Vomiting", icon: "🤢" },
+  { id: "dizziness", label_en: "Dizziness", label_el: "Ζάλη", fill: "Dizziness", icon: "😵" },
+  { id: "back_pain", label_en: "Back pain", label_el: "Πόνος στη μέση", fill: "Back pain", icon: "🧎" },
+  { id: "fatigue", label_en: "Fatigue", label_el: "Κόπωση", fill: "Fatigue / Weakness", icon: "😴" },
+]

--- a/frontend/app/management/page.tsx
+++ b/frontend/app/management/page.tsx
@@ -1,0 +1,553 @@
+"use client"
+
+import { useEffect, useState, useMemo, useRef } from "react"
+import Link from "next/link"
+import { useTriageStream } from "@/app/lib/useTriageStream"
+import { resolveApiBase, buildApiUrl } from "@/app/lib/backendResolver"
+import { useLang } from "@/app/lib/lang-context"
+import { toCaps } from "@/app/lib/casing"
+
+interface NimWarmup {
+  enabled: boolean
+  ready: boolean
+  model: string
+  timeout_seconds: number
+  max_retries: number
+  retry_delay_seconds: number
+  in_progress: boolean
+  attempts: number
+  started_at: string | null
+  last_attempt_at: string | null
+  last_success_at: string | null
+  last_error: string | null
+}
+
+interface NimStatusResponse {
+  status: string
+  warmup: NimWarmup
+}
+
+interface MtsBucket { mts_level: number; count: number }
+interface SpecialtyBucket { specialty: string; count: number }
+interface LangBucket { lang: string; count: number }
+
+interface AnalyticsData {
+  total_triages: number
+  unique_patients: number
+  avg_mts_level: number | null
+  rag_percentage: number
+  mts_distribution: MtsBucket[]
+  specialty_distribution: SpecialtyBucket[]
+  lang_distribution: LangBucket[]
+}
+
+interface DurationStats {
+  min: number
+  max: number
+  mean: number
+  median: number
+  p95: number
+}
+
+interface RagDebugStats {
+  trace_count?: number
+  error_count?: number
+  error_rate_pct?: number
+  duration_stats_ms?: DurationStats
+  distance_stats?: { min: number; max: number; mean: number }
+  top_warnings?: Record<string, number>
+  message?: string
+}
+
+const MTS_COLORS: Record<number, { bg: string; text: string; label: string }> = {
+  1: { bg: "bg-red-500",    text: "text-red-500",    label: "Immediate"   },
+  2: { bg: "bg-orange-500", text: "text-orange-500", label: "Very Urgent" },
+  3: { bg: "bg-yellow-500", text: "text-yellow-500", label: "Urgent"      },
+  4: { bg: "bg-green-500",  text: "text-green-500",  label: "Less Urgent" },
+  5: { bg: "bg-blue-500",   text: "text-blue-500",   label: "Non-Urgent"  },
+}
+
+const MTS_COLORS_EL: Record<number, string> = {
+  1: "Άμεσο", 2: "Πολύ Επείγον", 3: "Επείγον", 4: "Τυπικό", 5: "Μη Επείγον",
+}
+
+const QUEUE_MTS_LABELS: Record<number, string> = {
+  1: "Immediate", 2: "Very Urgent", 3: "Urgent", 4: "Less Urgent", 5: "Non-Urgent",
+}
+
+const QUEUE_MTS_COLOR_CLASS: Record<number, string> = {
+  1: "bg-destructive text-destructive-foreground",
+  2: "bg-destructive text-destructive-foreground",
+  3: "bg-warning text-background",
+  4: "bg-success text-background",
+  5: "bg-info text-background",
+}
+
+function Sparkline({ data, width, height, color }: { data: number[]; width: number; height: number; color: string }) {
+  if (data.length < 2) return <div className="flex items-center justify-center h-full text-xs text-muted-foreground">—</div>
+  const max = Math.max(...data, 1)
+  const min = Math.min(...data, 0)
+  const range = max - min || 1
+  const points = data.map((v, i) => `${(i / (data.length - 1)) * width},${height - ((v - min) / range) * height}`).join(" ")
+  return (
+    <svg width={width} height={height} className="block">
+      <polyline points={points} fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" />
+      {data.map((v, i) => {
+        const x = (i / (data.length - 1)) * width
+        const y = height - ((v - min) / range) * height
+        return <circle key={i} cx={x} cy={y} r={1.5} fill={color} />
+      })}
+    </svg>
+  )
+}
+
+function HorizontalBar({ label, value, max, color }: { label: string; value: number; max: number; color: string }) {
+  const pct = Math.min((value / Math.max(max, 1)) * 100, 100)
+  return (
+    <div className="flex items-center gap-2 text-[11px]">
+      <span className="w-12 text-right text-muted-foreground flex-shrink-0">{label}</span>
+      <div className="flex-1 h-3 rounded-full bg-muted overflow-hidden">
+        <div className="h-full rounded-full transition-all duration-500" style={{ width: `${pct}%`, backgroundColor: color }} />
+      </div>
+      <span className="w-16 text-left text-foreground font-mono tabular-nums flex-shrink-0">{value.toFixed(0)}ms</span>
+    </div>
+  )
+}
+
+function Card({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div className={`triage-card rounded-2xl border border-primary/20 bg-card p-5 ${className ?? ""}`}>
+      {children}
+    </div>
+  )
+}
+
+function ShimmerBlock({ height }: { height?: string }) {
+  return <div className={`skeleton rounded-xl animate-pulse ${height ?? "h-32"}`} />
+}
+
+export default function ManagementPage() {
+  const { lang } = useLang()
+
+  const [nim, setNim] = useState<NimWarmup | null>(null)
+  const [nimLoading, setNimLoading] = useState(true)
+
+  const [analytics, setAnalytics] = useState<AnalyticsData | null>(null)
+  const [analyticsLoading, setAnalyticsLoading] = useState(true)
+
+  const [ragStats, setRagStats] = useState<RagDebugStats | null>(null)
+  const [ragLoading, setRagLoading] = useState(true)
+
+  const [healthPings, setHealthPings] = useState<number[]>([])
+  const [lastPing, setLastPing] = useState<number | null>(null)
+  const maxPings = 40
+
+  const queueEntries = useTriageStream()
+  const [throughput, setThroughput] = useState<number[]>(Array(20).fill(0))
+  const throughputInterval = useRef<ReturnType<typeof setInterval> | null>(null)
+  const entryCountRef = useRef(0)
+
+  useEffect(() => {
+    entryCountRef.current = queueEntries.length
+  }, [queueEntries])
+
+  useEffect(() => {
+    throughputInterval.current = setInterval(() => {
+      setThroughput((prev) => {
+        const next = [...prev.slice(1), entryCountRef.current]
+        return next
+      })
+    }, 3000)
+    return () => { if (throughputInterval.current) clearInterval(throughputInterval.current) }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    const ping = async () => {
+      if (cancelled) return
+      const start = performance.now()
+      try {
+        const base = await resolveApiBase()
+        await fetch(buildApiUrl(base, "/api/v1/health"), { signal: AbortSignal.timeout(3000) })
+        const duration = Math.round(performance.now() - start)
+        if (!cancelled) {
+          setLastPing(duration)
+          setHealthPings((prev) => {
+            const next = [...prev, duration].slice(-maxPings)
+            return next
+          })
+        }
+      } catch {
+        if (!cancelled) {
+          setLastPing(null)
+          setHealthPings((prev) => [...prev, 0].slice(-maxPings))
+        }
+      }
+    }
+
+    ping()
+    const interval = setInterval(ping, 5000)
+    return () => { cancelled = true; clearInterval(interval) }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    resolveApiBase()
+      .then((base) => fetch(buildApiUrl(base, "/api/v1/health/warmup")))
+      .then((res) => res.json())
+      .then((val: NimStatusResponse) => { if (!cancelled) { setNim(val.warmup); setNimLoading(false) } })
+      .catch(() => { if (!cancelled) setNimLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    resolveApiBase()
+      .then((base) => fetch(buildApiUrl(base, "/api/v1/analytics")))
+      .then((res) => { if (!res.ok) throw new Error(`${res.status}`); return res.json() as Promise<AnalyticsData> })
+      .then((val) => { if (!cancelled) { setAnalytics(val); setAnalyticsLoading(false) } })
+      .catch(() => { if (!cancelled) setAnalyticsLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    resolveApiBase()
+      .then((base) => fetch(buildApiUrl(base, "/api/v1/rag/debug/stats")))
+      .then((res) => { if (!res.ok) throw new Error(`${res.status}`); return res.json() as Promise<RagDebugStats> })
+      .then((val) => { if (!cancelled) { setRagStats(val); setRagLoading(false) } })
+      .catch(() => { if (!cancelled) setRagLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  const queueCounts = useMemo(() => {
+    const counts: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
+    queueEntries.forEach((e) => {
+      if (counts[e.mts_level] !== undefined) counts[e.mts_level]++
+    })
+    return counts
+  }, [queueEntries])
+
+  const avgPing = useMemo(() => {
+    const valid = healthPings.filter((p) => p > 0)
+    return valid.length > 0 ? Math.round(valid.reduce((a, b) => a + b, 0) / valid.length) : null
+  }, [healthPings])
+
+  const throughputDelta = useMemo(() => {
+    if (throughput.length < 2) return 0
+    return throughput[throughput.length - 1] - throughput[throughput.length - 2]
+  }, [throughput])
+
+  return (
+    <div className="hero-section relative min-h-screen flex flex-col">
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="hero-orb-1 absolute w-[600px] h-[600px] rounded-full -top-32 -left-16" />
+        <div className="hero-orb-2 absolute w-[480px] h-[480px] rounded-full -bottom-24 -right-16" />
+      </div>
+
+      <div className="relative flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8 space-y-5">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Link
+              href="/"
+              className="w-10 h-10 rounded-full flex items-center justify-center border border-border/50 bg-card/60 backdrop-blur-md shadow-lg transition-colors hover:bg-card/80"
+              aria-label="Back to home"
+            >
+              <svg className="w-[16px] h-[16px] text-foreground/70" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+              </svg>
+            </Link>
+            <h1 className="text-xl font-bold text-foreground">
+              MED<span className="logo-omega text-primary">Ω</span>
+            </h1>
+          </div>
+          <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase hidden sm:block">
+            Management
+          </p>
+          <div className="flex items-center gap-2 text-[10px] font-mono text-muted-foreground">
+            <span className={`inline-block w-2 h-2 rounded-full ${healthPings.length > 0 && healthPings[healthPings.length - 1] > 0 ? "bg-success" : "bg-destructive"}`} />
+            {lastPing !== null ? `${lastPing}ms` : "—"}
+          </div>
+        </div>
+
+        {/* ─── Row 1: Status Gauges (4 cols) ─── */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <Card>
+            <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase mb-2">NIM Status</p>
+            {nimLoading ? (
+              <ShimmerBlock height="h-16" />
+            ) : nim ? (
+              <div>
+                <div className="flex items-center gap-2 mb-1">
+                  <span className={`inline-block w-2.5 h-2.5 rounded-full ${nim.ready ? "bg-success" : nim.in_progress ? "bg-warning" : "bg-destructive"}`} />
+                  <span className="text-lg font-black text-foreground">{nim.ready ? "Ready" : nim.in_progress ? "Warming" : "Down"}</span>
+                </div>
+                <p className="text-[10px] text-muted-foreground">{nim.model.split("/").pop()}</p>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">Unreachable</p>
+            )}
+          </Card>
+
+          <Card>
+            <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase mb-2">Health Ping</p>
+            <div>
+              <div className="flex items-baseline gap-1">
+                <span className="text-lg font-black text-foreground">{avgPing ?? "—"}</span>
+                <span className="text-[10px] text-muted-foreground">{avgPing !== null ? "ms avg" : ""}</span>
+              </div>
+              <div className="h-8 mt-1">
+                <Sparkline data={healthPings} width={120} height={32} color="#3b82f6" />
+              </div>
+            </div>
+          </Card>
+
+          <Card>
+            <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase mb-2">Throughput</p>
+            <div>
+              <div className="flex items-baseline gap-1">
+                <span className="text-lg font-black text-foreground">{queueEntries.length}</span>
+                <span className="text-[10px] text-muted-foreground">total</span>
+              </div>
+              <p className="text-[10px] text-muted-foreground">
+                {throughputDelta > 0 ? `+${throughputDelta} / 3s` : throughputDelta < 0 ? `${throughputDelta} / 3s` : "steady"}
+              </p>
+            </div>
+          </Card>
+
+          <Card>
+            <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase mb-2">Total Triages</p>
+            {analyticsLoading ? (
+              <ShimmerBlock height="h-16" />
+            ) : (
+              <div>
+                <span className="text-lg font-black text-foreground">{analytics?.total_triages?.toLocaleString() ?? 0}</span>
+                <p className="text-[10px] text-muted-foreground">{analytics?.unique_patients ?? 0} patients</p>
+              </div>
+            )}
+          </Card>
+        </div>
+
+        {/* ─── Row 2: Latency Sparkline + Pipeline Stats (2 cols) ─── */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+          <Card>
+            <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase mb-2">API Latency (last {maxPings} pings)</p>
+            <div className="h-20">
+              <Sparkline data={healthPings} width={400} height={80} color="#3b82f6" />
+            </div>
+            <div className="flex justify-between text-[10px] text-muted-foreground mt-1">
+              <span>min: {healthPings.filter((p) => p > 0).length > 0 ? Math.min(...healthPings.filter((p) => p > 0)) : "—"}ms</span>
+              <span>max: {healthPings.filter((p) => p > 0).length > 0 ? Math.max(...healthPings.filter((p) => p > 0)) : "—"}ms</span>
+              <span>avg: {avgPing ?? "—"}ms</span>
+              <span>pings: {healthPings.filter((p) => p > 0).length}</span>
+            </div>
+          </Card>
+
+          <Card>
+            <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase mb-2">NIM Pipeline Duration</p>
+            {ragLoading ? (
+              <ShimmerBlock height="h-20" />
+            ) : ragStats?.duration_stats_ms ? (
+              <div className="space-y-1.5">
+                <HorizontalBar label="p95" value={ragStats.duration_stats_ms.p95} max={ragStats.duration_stats_ms.max} color="#ef4444" />
+                <HorizontalBar label="median" value={ragStats.duration_stats_ms.median} max={ragStats.duration_stats_ms.max} color="#f59e0b" />
+                <HorizontalBar label="mean" value={ragStats.duration_stats_ms.mean} max={ragStats.duration_stats_ms.max} color="#3b82f6" />
+                <HorizontalBar label="min" value={ragStats.duration_stats_ms.min} max={ragStats.duration_stats_ms.max} color="#22c55e" />
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">{ragStats?.message ?? "No pipeline data"}</p>
+            )}
+            {ragStats?.error_count !== undefined && (
+              <div className="flex gap-4 mt-3 text-[10px] text-muted-foreground">
+                <span>Traces: {ragStats.trace_count}</span>
+                <span>Errors: {ragStats.error_count} ({ragStats.error_rate_pct}%)</span>
+              </div>
+            )}
+          </Card>
+        </div>
+
+        {/* ─── Row 3: MTS Distribution + Top Specialties (2 cols) ─── */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+          <Card>
+            <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase mb-3">
+              {toCaps("MTS Distribution", lang)}
+            </p>
+            {analyticsLoading ? (
+              <ShimmerBlock height="h-28" />
+            ) : analytics && analytics.total_triages > 0 ? (
+              <div className="space-y-2">
+                {analytics.mts_distribution.map((item) => {
+                  const palette = MTS_COLORS[item.mts_level] ?? MTS_COLORS[5]
+                  const pct = Math.max((item.count / analytics.total_triages) * 100, 0)
+                  const label = lang === "el" ? MTS_COLORS_EL[item.mts_level] ?? `L${item.mts_level}` : `L${item.mts_level}`
+                  return (
+                    <div key={item.mts_level} className="flex items-center gap-2">
+                      <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${palette.bg}`} />
+                      <span className="text-xs text-foreground w-16 flex-shrink-0">{label}</span>
+                      <div className="flex-1 h-2 rounded-full bg-muted overflow-hidden">
+                        <div className={`h-full rounded-full ${palette.bg} transition-all duration-500`} style={{ width: `${pct}%` }} />
+                      </div>
+                      <span className={`text-[11px] font-semibold tabular-nums w-10 text-right flex-shrink-0 ${palette.text}`}>{item.count}</span>
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">No data</p>
+            )}
+          </Card>
+
+          <Card>
+            <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase mb-3">
+              {toCaps("Top Specialties", lang)}
+            </p>
+            {analyticsLoading ? (
+              <ShimmerBlock height="h-28" />
+            ) : analytics && analytics.total_triages > 0 ? (
+              <div className="space-y-1.5">
+                {analytics.specialty_distribution.slice(0, 8).map((item, idx) => {
+                  const pct = Math.max((item.count / analytics.total_triages) * 100, 0)
+                  return (
+                    <div key={item.specialty} className="flex items-center gap-2">
+                      <span className="text-[10px] font-bold text-muted-foreground w-3 text-right flex-shrink-0">{idx + 1}</span>
+                      <span className="text-xs text-foreground truncate flex-1 min-w-0">{item.specialty}</span>
+                      <div className="w-20 h-1.5 rounded-full bg-muted overflow-hidden flex-shrink-0">
+                        <div className="h-full rounded-full bg-info transition-all duration-500" style={{ width: `${pct}%` }} />
+                      </div>
+                      <span className="text-[10px] font-semibold text-muted-foreground w-8 text-right flex-shrink-0 tabular-nums">{item.count}</span>
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">No data</p>
+            )}
+          </Card>
+        </div>
+
+        {/* ─── Row 4: Language + Queue MTS counts ─── */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
+          <Card>
+            <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase mb-2">
+              {toCaps("Language", lang)}
+            </p>
+            {analytics && analytics.lang_distribution.length > 0 ? (
+              <div className="flex gap-2">
+                {analytics.lang_distribution.map((item) => {
+                  const pct = Math.round((item.count / analytics.total_triages) * 100)
+                  return (
+                    <div key={item.lang} className="flex-1 rounded-lg border border-border bg-muted/30 p-2 text-center">
+                      <p className="text-lg font-black text-foreground">{pct}%</p>
+                      <p className="text-[10px] text-muted-foreground">{item.lang === "en" ? "EN" : "EL"}</p>
+                    </div>
+                  )
+                })}
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">—</p>
+            )}
+          </Card>
+
+          <Card>
+            <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase mb-2">
+              {toCaps("Queue by Level", lang)}
+            </p>
+            <div className="grid grid-cols-5 gap-1.5">
+              {[1, 2, 3, 4, 5].map((level) => {
+                const palette = MTS_COLORS[level] ?? MTS_COLORS[5]
+                return (
+                  <div key={level} className="rounded-lg border border-border bg-muted/30 p-2 text-center">
+                    <p className={`text-sm font-black ${palette.text}`}>{queueCounts[level] ?? 0}</p>
+                    <p className="text-[9px] font-semibold text-muted-foreground">L{level}</p>
+                  </div>
+                )
+              })}
+            </div>
+          </Card>
+
+          <Card>
+            <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase mb-2">
+              {toCaps("RAG Coverage", lang)}
+            </p>
+            {ragLoading ? (
+              <ShimmerBlock height="h-16" />
+            ) : ragStats?.distance_stats ? (
+              <div className="space-y-1">
+                <div className="flex justify-between text-[11px]">
+                  <span className="text-muted-foreground">Chunk distance</span>
+                  <span className="text-foreground font-mono">{ragStats.distance_stats.mean.toFixed(3)}</span>
+                </div>
+                <div className="flex justify-between text-[11px]">
+                  <span className="text-muted-foreground">Min</span>
+                  <span className="text-foreground font-mono">{ragStats.distance_stats.min.toFixed(3)}</span>
+                </div>
+                <div className="flex justify-between text-[11px]">
+                  <span className="text-muted-foreground">Max</span>
+                  <span className="text-foreground font-mono">{ragStats.distance_stats.max.toFixed(3)}</span>
+                </div>
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">{ragStats?.message ?? "No data"}</p>
+            )}
+          </Card>
+        </div>
+
+        {/* ─── Row 5: Live Triage Queue ─── */}
+        <Card>
+          <div className="flex items-center justify-between mb-4">
+            <p className="text-[10px] font-bold tracking-[0.15em] text-muted-foreground uppercase">
+              {toCaps("Live Triage Queue", lang)}
+            </p>
+            <span className="text-[10px] text-muted-foreground font-mono">{queueEntries.length} entries</span>
+          </div>
+
+          {queueEntries.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              No triage events recorded yet.
+            </p>
+          ) : (
+            <div className="overflow-x-auto -mx-1">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="text-left py-2 px-2 text-[9px] font-bold tracking-[0.15em] text-muted-foreground uppercase">Time</th>
+                    <th className="text-left py-2 px-2 text-[9px] font-bold tracking-[0.15em] text-muted-foreground uppercase">Patient ID</th>
+                    <th className="text-left py-2 px-2 text-[9px] font-bold tracking-[0.15em] text-muted-foreground uppercase">Level</th>
+                    <th className="text-left py-2 px-2 text-[9px] font-bold tracking-[0.15em] text-muted-foreground uppercase">Specialty</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {queueEntries.slice(0, 35).map((entry) => {
+                    const badge = QUEUE_MTS_COLOR_CLASS[entry.mts_level] ?? "bg-gray-500 text-white"
+                    const label = QUEUE_MTS_LABELS[entry.mts_level] ?? `L${entry.mts_level}`
+                    const date = new Date(entry.timestamp)
+                    const time = Number.isNaN(date.getTime())
+                      ? "—"
+                      : date.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", second: "2-digit" })
+                    const rowBg = entry.mts_level <= 2 ? "bg-destructive/5" : ""
+                    return (
+                      <tr key={`${entry.patient_id}-${entry.timestamp}`} className={`border-b border-border/40 ${rowBg}`}>
+                        <td className="py-1.5 px-2 text-[11px] text-muted-foreground font-mono whitespace-nowrap">{time}</td>
+                        <td className="py-1.5 px-2 text-[11px] text-foreground font-mono">{entry.patient_id.slice(0, 10)}...</td>
+                        <td className="py-1.5 px-2">
+                          <span className={`inline-block px-1.5 py-0.5 rounded-full text-[9px] font-bold ${badge}`}>{label}</span>
+                        </td>
+                        <td className="py-1.5 px-2 text-[11px] text-foreground whitespace-nowrap">{entry.specialty}</td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {queueEntries.length > 35 && (
+            <p className="text-[10px] text-muted-foreground mt-2 text-center">
+              Showing 35 of {queueEntries.length} entries
+            </p>
+          )}
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,12 +1,12 @@
 "use client"
 
-import { useState, useRef, useEffect, useMemo } from "react"
+import { useState, useRef, useEffect } from "react"
+import { useSearchParams } from "next/navigation"
 import TriageForm from "@/app/components/TriageForm"
 import TriageResult from "@/app/components/TriageResult"
 import SymptomWizard from "@/app/components/SymptomWizard"
 import SkeletonTriageResult from "@/app/components/SkeletonTriageResult"
 import FollowUpGuidance from "@/app/components/FollowUpGuidance"
-import Tabs from "@/app/components/Tabs"
 import HistoryList from "@/app/components/HistoryList"
 import Disclaimer from "@/app/components/Disclaimer"
 import TeamSection from "@/app/components/TeamSection"
@@ -28,10 +28,11 @@ function generatePatientId(): string {
 }
 
 export default function Home() {
+  const searchParams = useSearchParams()
+  const showHistory = searchParams.get("history") === "1"
   const [result, setResult] = useState<TriageResponse | null>(null)
   const [loading, setLoading] = useState(false)
   const [heroVisible, setHeroVisible] = useState(true)
-  const [activeTab, setActiveTab] = useState<"form" | "history">("form")
   const [useWizard, setUseWizard] = useState(false)
   const heroRef = useRef<HTMLElement>(null)
   const { t, lang } = useLang()
@@ -61,14 +62,6 @@ export default function Home() {
     setResult(r)
     setLoading(false)
   }
-
-  const tabs = useMemo(
-    () => [
-      { id: "form", label: t.history.newAssessment },
-      { id: "history", label: t.history.title, tabId: "tab-history" },
-    ],
-    [t.history.newAssessment, t.history.title]
-  )
 
   const scrollToBottom = () => {
     const bottomAnchor = document.getElementById("page-bottom")
@@ -102,11 +95,11 @@ export default function Home() {
         </div>
 
         <div className="relative flex-1 w-full flex flex-col items-center justify-center py-16">
-          <div className={`w-full ${result === null ? "max-w-xl" : "max-w-2xl"}`}>
+          <div className={`w-full ${result === null ? (useWizard ? "max-w-3xl" : "max-w-xl") : "max-w-2xl"}`}>
             {/* Logo */}
             <div className="mb-8 text-center">
               <button
-                onClick={() => { setResult(null); setLoading(false); setActiveTab("form") }}
+                onClick={() => { setResult(null); setLoading(false) }}
                 className="group focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 rounded-lg"
                 title={t.hero.logoTitle}
               >
@@ -121,76 +114,86 @@ export default function Home() {
 
             {/* Card */}
             <div className="triage-card rounded-2xl border border-primary/20 bg-card p-6 sm:p-8">
-              <div className="mb-6">
-                <Tabs
-                  tabs={tabs}
-                  activeTab={activeTab}
-                  onChange={(id) => setActiveTab(id as "form" | "history")}
-                />
-              </div>
 
-              {activeTab === "history" ? (
+              {showHistory ? (
                 <HistoryList patientId={patientId} />
               ) : loading ? (
                 <SkeletonTriageResult />
               ) : result === null ? (
-                useWizard ? (
+                <div key={useWizard ? "wizard" : "text"} className="animate-[fadeIn_200ms_ease-out]">
+                {useWizard ? (
                   <SymptomWizard patientId={patientId} onResult={handleResult} onStartLoading={handleStartLoading} latitude={geo.latitude} longitude={geo.longitude} />
                 ) : (
-                  <TriageForm onResult={handleResult} onStartLoading={handleStartLoading} patientId={patientId} latitude={geo.latitude} longitude={geo.longitude} />
-                )
+                  <TriageForm onResult={handleResult} onStartLoading={handleStartLoading} patientId={patientId} latitude={geo.latitude} longitude={geo.longitude} geoDenied={geo.denied} geoLoading={geo.loading} geoDismissed={geo.dismissed} onRequestLocation={geo.request} />
+                )}
+                </div>
               ) : (
                 <>
                   <TriageResult result={result} userLat={geo.latitude} userLon={geo.longitude} />
                   <FollowUpGuidance mtsLevel={result.mts_level} />
+
+                  {geo.latitude === null && (
+                    <div className="mt-4 flex items-center justify-between gap-2 rounded-lg border border-primary/20 bg-primary/5 px-4 py-3">
+                      <span className="text-sm text-muted-foreground flex-1">{t.doctor.locationBanner}</span>
+                      <button
+                        type="button"
+                        onClick={geo.request}
+                        disabled={geo.loading}
+                        className="shrink-0 rounded-full bg-primary px-3 py-1 text-xs font-medium text-white hover:bg-primary-hover transition-colors"
+                      >
+                        {geo.loading ? "..." : t.doctor.enableLocation}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={geo.dismiss}
+                        className="shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        {t.doctor.skipLocation}
+                      </button>
+                    </div>
+                  )}
                 </>
               )}
 
-              {/* Location permission banner */}
-              {activeTab === "form" && geo.latitude === null && !geo.denied && (
-                <div className="flex items-center justify-between gap-3 rounded-lg border border-primary/20 bg-primary/5 px-4 py-3 text-sm text-foreground">
-                  <span className="flex-1">{t.doctor.locationBanner}</span>
-                  {geo.loading ? (
-                    <span className="text-muted-foreground animate-pulse">...</span>
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={geo.request}
-                      className="shrink-0 rounded-full bg-primary px-3 py-1 text-xs font-medium text-white hover:bg-primary-hover transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
-                    >
-                      {t.doctor.enableLocation}
-                    </button>
-                  )}
+              {/* Mode switcher — pill toggle between free-text and wizard */}
+              {!showHistory && result === null && !loading && (
+                <div className="flex gap-2 rounded-xl bg-muted/60 p-1.5 mt-2 mb-4">
                   <button
+                    id="mode-text"
                     type="button"
-                    onClick={() => geo.denied || true}
-                    className="shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                    style={{ visibility: geo.loading ? "hidden" : "visible" }}
+                    onClick={() => setUseWizard(false)}
+                    className={`flex-1 flex items-center justify-center gap-1.5 rounded-lg px-4 py-2.5 text-xs font-bold transition-all duration-200 ${
+                      !useWizard
+                        ? "bg-primary text-white shadow-md shadow-primary/20"
+                        : "text-muted-foreground hover:text-foreground hover:bg-white/30 dark:hover:bg-white/5 shadow-[inset_0_1px_3px_rgba(0,0,0,0.12)] dark:shadow-[inset_0_1px_4px_rgba(0,0,0,0.45)]"
+                    }`}
                   >
-                    {t.doctor.skipLocation}
+                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
+                    </svg>
+                    {toCaps(lang === "el" ? "Ελεύθερο Κείμενο" : "Free Text", lang)}
+                  </button>
+                  <button
+                    id="mode-wizard"
+                    type="button"
+                    onClick={() => setUseWizard(true)}
+                    className={`flex-1 flex items-center justify-center gap-1.5 rounded-lg px-4 py-2.5 text-xs font-bold transition-all duration-200 ${
+                      useWizard
+                        ? "bg-primary text-white shadow-md shadow-primary/20"
+                        : "text-muted-foreground hover:text-foreground hover:bg-white/30 dark:hover:bg-white/5 shadow-[inset_0_1px_3px_rgba(0,0,0,0.12)] dark:shadow-[inset_0_1px_4px_rgba(0,0,0,0.45)]"
+                    }`}
+                  >
+                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" />
+                    </svg>
+                    {toCaps(lang === "el" ? "Καθοδηγούμενο" : "Guided", lang)}
                   </button>
                 </div>
-              )}
-
-              {activeTab === "form" && geo.denied && (
-                <p className="text-xs text-muted-foreground text-center">{t.doctor.locationDenied}</p>
-              )}
-
-              {/* Wizard / free-text toggle */}
-              {activeTab === "form" && result === null && !loading && (
-                <button
-                  id="wizard-toggle"
-                  type="button"
-                  onClick={() => setUseWizard(!useWizard)}
-                  className="mt-4 block mx-auto text-xs text-muted-foreground hover:text-primary transition-colors underline underline-offset-2"
-                >
-                  {useWizard ? t.wizard.freeText : t.wizard.tryWizardLink}
-                </button>
               )}
             </div>
 
             {/* Back button */}
-            {result !== null && activeTab === "form" && (
+            {result !== null && !showHistory && (
               <div className="mt-4">
                 <button
                   type="button"


### PR DESCRIPTION
- Add /management page with live triage queue, NIM health status, analytics, network latency sparklines, and pipeline duration stats
- Add /doctors page with login (select doctor + password "password") and specialty-filtered patient queue grouped by triage level
- Redesign assessment box: pill-style mode switcher (Free Text/Guided), rotating daily prompt, quick symptom chips with smooth collapse
- Redesign SymptomWizard: segmented progress bar, centered icon cards, responsive 4-column body area grid, server-safe random prompt
- Remove InstallPrompt PWA banner from layout
- Remove Assessment History tab; replace with HistoryToggle button in floating bar using search params for view switching
- Remove system theme; ThemeToggle now switches light/dark only
- Add silent IP-based geolocation (no browser permission needed)
- Inline location prompt in TriageForm and result view
- Fix ManagementLink button styling (theme-toggle-btn class)
- Fix Next.js smooth-scroll warning (data-scroll-behavior attribute)
- Fix various hydration mismatches in random prompt generation